### PR TITLE
Fix printing MCP tool name when doing registry list

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -126,13 +126,8 @@ func printTextServers(servers []*registry.Server) {
 
 	// Print server information
 	for _, server := range servers {
-		// Extract server name from image
-		name := strings.Split(server.Image, ":")[0]
-		name = strings.TrimPrefix(name, "mcp/")
-
-		// Print server information
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\n",
-			name,
+			server.Name,
 			truncateString(server.Description, 60),
 			server.Transport,
 			server.Metadata.Stars,
@@ -149,7 +144,7 @@ func printTextServers(servers []*registry.Server) {
 // printTextServerInfo prints detailed information about a server in text format
 // nolint:gocyclo
 func printTextServerInfo(name string, server *registry.Server) {
-	fmt.Printf("Name: %s\n", name)
+	fmt.Printf("Name: %s\n", server.Name)
 	fmt.Printf("Image: %s\n", server.Image)
 	fmt.Printf("Description: %s\n", server.Description)
 	fmt.Printf("Transport: %s\n", server.Transport)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -33,6 +33,11 @@ func GetRegistry() (*Registry, error) {
 			registryErr = fmt.Errorf("failed to parse registry data: %w", err)
 			return
 		}
+
+		// Set name field on each server based on map key
+		for name, server := range registry.Servers {
+			server.Name = name
+		}
 	})
 
 	return registry, registryErr

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -16,6 +16,7 @@ type Registry struct {
 
 // Server represents an MCP server in the registry
 type Server struct {
+	Name          string               `json:"name,omitempty"`
 	Image         string               `json:"image"`
 	Description   string               `json:"description"`
 	Transport     string               `json:"transport"`


### PR DESCRIPTION
We were printing the container image instead of the name, which is not
ideal. This fixes that.

Closes: https://github.com/StacklokLabs/toolhive/issues/154
Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
