### PR TITLE
Call to update service on startup

### DIFF
--- a/cmd/thv/app/version.go
+++ b/cmd/thv/app/version.go
@@ -2,38 +2,12 @@ package app
 
 import (
 	"fmt"
-	"runtime"
-	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
-)
 
-const (
-	unknownStr = "unknown"
+	"github.com/StacklokLabs/toolhive/pkg/versions"
 )
-
-// Version information set by build using -ldflags
-var (
-	// Version is the current version of ToolHive
-	Version = "dev"
-	// Commit is the git commit hash of the build
-	//nolint:goconst // This is a placeholder for the commit hash
-	Commit = unknownStr
-	// BuildDate is the date when the binary was built
-	// nolint:goconst // This is a placeholder for the build date
-	BuildDate = unknownStr
-)
-
-// versionInfo represents the version information
-type versionInfo struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"build_date"`
-	GoVersion string `json:"go_version"`
-	Platform  string `json:"platform"`
-}
 
 // newVersionCmd creates a new version command
 func newVersionCmd() *cobra.Command {
@@ -44,7 +18,7 @@ func newVersionCmd() *cobra.Command {
 		Short: "Show the version of ToolHive",
 		Long:  `Display detailed version information about ToolHive, including version number, git commit, build date, and Go version.`,
 		Run: func(_ *cobra.Command, _ []string) {
-			info := getVersionInfo()
+			info := versions.GetVersionInfo()
 
 			if jsonOutput {
 				printJSONVersionInfo(info)
@@ -59,49 +33,8 @@ func newVersionCmd() *cobra.Command {
 	return cmd
 }
 
-// getVersionInfo returns the version information
-func getVersionInfo() versionInfo {
-	// If version is still "dev", try to get it from build info
-	ver := Version
-	commit := Commit
-	buildDate := BuildDate
-
-	if ver == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok {
-			// Try to get version from build info
-			for _, setting := range info.Settings {
-				switch setting.Key {
-				case "vcs.revision":
-					if commit == unknownStr {
-						commit = setting.Value
-					}
-				case "vcs.time":
-					if buildDate == unknownStr {
-						buildDate = setting.Value
-					}
-				}
-			}
-		}
-	}
-
-	// Format the build date if it's a timestamp
-	if buildDate != unknownStr {
-		if t, err := time.Parse(time.RFC3339, buildDate); err == nil {
-			buildDate = t.Format("2006-01-02 15:04:05 MST")
-		}
-	}
-
-	return versionInfo{
-		Version:   ver,
-		Commit:    commit,
-		BuildDate: buildDate,
-		GoVersion: runtime.Version(),
-		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-	}
-}
-
 // printVersionInfo prints the version information
-func printVersionInfo(info versionInfo) {
+func printVersionInfo(info versions.VersionInfo) {
 	fmt.Printf("ToolHive %s\n", info.Version)
 	fmt.Printf("Commit: %s\n", info.Commit)
 	fmt.Printf("Built: %s\n", info.BuildDate)
@@ -110,7 +43,7 @@ func printVersionInfo(info versionInfo) {
 }
 
 // printJSONVersionInfo prints the version information as JSON
-func printJSONVersionInfo(info versionInfo) {
+func printJSONVersionInfo(info versions.VersionInfo) {
 	// Simple JSON formatting without importing encoding/json
 	jsonStr := fmt.Sprintf(`{
   "version": "%s",

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -6,14 +6,32 @@ import (
 
 	"github.com/StacklokLabs/toolhive/cmd/thv/app"
 	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/StacklokLabs/toolhive/pkg/updates"
 )
 
 func main() {
 	// Initialize the logger system
 	logger.Initialize()
 
+	checkForUpdates()
+
 	if err := app.NewRootCmd().Execute(); err != nil {
 		logger.Log.Error("%v, %v", os.Stderr, err)
 		os.Exit(1)
+	}
+}
+
+func checkForUpdates() {
+	versionClient := updates.NewVersionClient()
+	updateChecker, err := updates.NewUpdateChecker(versionClient)
+	// treat update-related errors as non-fatal
+	if err != nil {
+		logger.Log.Error("unable to create update client: %w", err)
+		return
+	}
+
+	err = updateChecker.CheckLatestVersion()
+	if err != nil {
+		logger.Log.Error("error while checking for updates: %w", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0 // indirect
 	golang.org/x/exp/event v0.0.0-20220217172124-1812c5b45e43 // indirect

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -1,0 +1,128 @@
+// Package updates contains logic for checking if an update is available for ToolHive.
+package updates
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/adrg/xdg"
+	"github.com/google/uuid"
+
+	"github.com/StacklokLabs/toolhive/pkg/versions"
+)
+
+// UpdateChecker is an interface for checking if a new version of ToolHive is available.
+type UpdateChecker interface {
+	// CheckLatestVersion checks if a new version of ToolHive is available
+	// and prints the result to the console.
+	CheckLatestVersion() error
+}
+
+// NewUpdateChecker creates a new instance of UpdateChecker.
+func NewUpdateChecker(versionClient VersionClient) (UpdateChecker, error) {
+	path, err := xdg.DataFile(updateFilePathSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("unable to access update file path %w", err)
+	}
+
+	// Check to see if the file already exists. Read the instance ID from the
+	// file if it does. If it doesn't exist, create a new instance ID.
+	var instanceID string
+	// #nosec G304: File path is not configurable at this time.
+	rawContents, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			instanceID = uuid.NewString()
+		} else {
+			return nil, fmt.Errorf("failed to read update file: %w", err)
+		}
+	} else {
+		var contents updateFile
+		err = json.Unmarshal(rawContents, &contents)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize update file: %w", err)
+		}
+		instanceID = contents.InstanceID
+	}
+
+	return &defaultUpdateChecker{
+		currentVersion: versions.GetVersionInfo().Version,
+		instanceID:     instanceID,
+		updateFilePath: path,
+		versionClient:  versionClient,
+	}, nil
+}
+
+const (
+	updateFilePathSuffix = "toolhive/updates.json"
+	updateInterval       = 4 * time.Hour
+)
+
+// updateFile represents the structure of the update file.
+type updateFile struct {
+	InstanceID    string `json:"instance_id"`
+	LatestVersion string `json:"latest_version"`
+}
+
+type defaultUpdateChecker struct {
+	instanceID          string
+	currentVersion      string
+	previousAPIResponse string
+	updateFilePath      string
+	versionClient       VersionClient
+}
+
+func (d *defaultUpdateChecker) CheckLatestVersion() error {
+	// Check if the update file exists.
+	// Ignore the error if the file doesn't exist - we'll create it later.
+	fileInfo, err := os.Stat(d.updateFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat update file: %w", err)
+	}
+
+	// Check if we need to make an API request based on file modification time.
+	if fileInfo != nil && time.Since(fileInfo.ModTime()) < updateInterval {
+		// If it is too soon - notify the user if we already know there is
+		// an update, then exit.
+		notifyIfUpdateAvailable(d.currentVersion, d.previousAPIResponse)
+		return nil
+	}
+
+	// If the update file is stale or does not exist - get the latest version
+	// from the API.
+	latestVersion, err := d.versionClient.GetLatestVersion(d.instanceID, d.currentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	notifyIfUpdateAvailable(d.currentVersion, latestVersion)
+
+	// Rewrite the update file with the latest result.
+	// If we really wanted to optimize this, we could skip updating the file
+	// if the version is the same as the current version, but update the
+	// modification time.
+	newFileContents := updateFile{
+		InstanceID:    d.instanceID,
+		LatestVersion: latestVersion,
+	}
+
+	updatedData, err := json.Marshal(newFileContents)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated data: %w", err)
+	}
+
+	if err := os.WriteFile(d.updateFilePath, updatedData, 0600); err != nil {
+		return fmt.Errorf("failed to write updated file: %w", err)
+	}
+
+	return nil
+}
+
+func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
+	// TODO: Consider using semver logic in future.
+	if currentVersion != latestVersion {
+		fmt.Printf("A new version of ToolHive is available: %s\n", latestVersion)
+	}
+}

--- a/pkg/updates/checker_test.go
+++ b/pkg/updates/checker_test.go
@@ -1,0 +1,280 @@
+package updates
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Constants for testing
+const (
+	testInstanceID     = "test-instance-id"
+	testCurrentVersion = "1.0.0"
+	testLatestVersion  = "1.1.0"
+	testOldVersion     = "1.0.5"
+)
+
+// MockVersionClient is a mock implementation of the VersionClient interface
+type MockVersionClient struct {
+	mock.Mock
+}
+
+func (m *MockVersionClient) GetLatestVersion(instanceID string, currentVersion string) (string, error) {
+	args := m.Called(instanceID, currentVersion)
+	return args.String(0), args.Error(1)
+}
+
+// Test helpers
+func setupMockVersionClient(_ *testing.T) *MockVersionClient {
+	return &MockVersionClient{}
+}
+
+// createTempDir creates a temporary directory for testing
+func createTempDir(t *testing.T) string {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "toolhive-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+	return tempDir
+}
+
+// createUpdateFile creates a temporary update file with the given contents
+func createUpdateFile(t *testing.T, dir string, contents updateFile) string {
+	t.Helper()
+	filePath := filepath.Join(dir, "updates.json")
+	data, err := json.Marshal(contents)
+	require.NoError(t, err)
+	err = os.WriteFile(filePath, data, 0600)
+	require.NoError(t, err)
+	return filePath
+}
+
+// TestCheckLatestVersion tests the CheckLatestVersion method
+func TestCheckLatestVersion(t *testing.T) {
+	t.Run("file doesn't exist - creates new file", func(t *testing.T) {
+		// Setup
+		mockClient := setupMockVersionClient(t)
+		tempDir := createTempDir(t)
+		updateFilePath := filepath.Join(tempDir, "updates.json")
+		instanceID := testInstanceID
+		currentVersion := testCurrentVersion
+		latestVersion := testLatestVersion
+
+		// Create the checker directly
+		checker := &defaultUpdateChecker{
+			instanceID:     instanceID,
+			currentVersion: currentVersion,
+			updateFilePath: updateFilePath,
+			versionClient:  mockClient,
+		}
+
+		// Mock client.GetLatestVersion
+		mockClient.On("GetLatestVersion", instanceID, currentVersion).Return(latestVersion, nil)
+
+		// Execute
+		err := checker.CheckLatestVersion()
+
+		// Verify
+		require.NoError(t, err)
+		mockClient.AssertExpectations(t)
+
+		// Verify that the file was created
+		_, err = os.Stat(updateFilePath)
+		assert.NoError(t, err)
+
+		// Read the file and verify its contents
+		data, err := os.ReadFile(updateFilePath)
+		require.NoError(t, err)
+
+		var fileContents updateFile
+		err = json.Unmarshal(data, &fileContents)
+		require.NoError(t, err)
+		assert.Equal(t, instanceID, fileContents.InstanceID)
+		assert.Equal(t, latestVersion, fileContents.LatestVersion)
+	})
+
+	t.Run("file exists but is stale - makes API call", func(t *testing.T) {
+		// Setup
+		mockClient := setupMockVersionClient(t)
+		tempDir := createTempDir(t)
+		instanceID := testInstanceID
+		currentVersion := testCurrentVersion
+		oldLatestVersion := testOldVersion
+		newLatestVersion := testLatestVersion
+
+		// Create an update file with a known instance ID
+		updateFilePath := createUpdateFile(t, tempDir, updateFile{
+			InstanceID:    instanceID,
+			LatestVersion: oldLatestVersion,
+		})
+
+		// Set the file's modification time to be older than updateInterval
+		staleTime := time.Now().Add(-5 * time.Hour)
+		err := os.Chtimes(updateFilePath, staleTime, staleTime)
+		require.NoError(t, err)
+
+		// Create the checker directly
+		checker := &defaultUpdateChecker{
+			instanceID:     instanceID,
+			currentVersion: currentVersion,
+			updateFilePath: updateFilePath,
+			versionClient:  mockClient,
+		}
+
+		// Mock client.GetLatestVersion - must be set up before calling CheckLatestVersion
+		mockClient.On("GetLatestVersion", instanceID, currentVersion).Return(newLatestVersion, nil)
+
+		// Execute
+		err = checker.CheckLatestVersion()
+
+		// Verify
+		require.NoError(t, err)
+		mockClient.AssertExpectations(t)
+
+		// Read the file and verify its contents
+		data, err := os.ReadFile(updateFilePath)
+		require.NoError(t, err)
+
+		var fileContents updateFile
+		err = json.Unmarshal(data, &fileContents)
+		require.NoError(t, err)
+		assert.Equal(t, instanceID, fileContents.InstanceID)
+		assert.Equal(t, newLatestVersion, fileContents.LatestVersion)
+	})
+
+	t.Run("file exists and is fresh - skips API call", func(t *testing.T) {
+		// Setup
+		mockClient := setupMockVersionClient(t)
+		tempDir := createTempDir(t)
+		instanceID := testInstanceID
+		currentVersion := testCurrentVersion
+		latestVersion := testLatestVersion
+
+		// Create an update file with a known instance ID
+		updateFilePath := createUpdateFile(t, tempDir, updateFile{
+			InstanceID:    instanceID,
+			LatestVersion: latestVersion,
+		})
+
+		// Set the file's modification time to be newer than updateInterval (less than 4 hours ago)
+		freshTime := time.Now().Add(-1 * time.Hour)
+		err := os.Chtimes(updateFilePath, freshTime, freshTime)
+		require.NoError(t, err)
+
+		// Create the checker directly
+		checker := &defaultUpdateChecker{
+			instanceID:          instanceID,
+			currentVersion:      currentVersion,
+			previousAPIResponse: latestVersion, // Set the previous API response
+			updateFilePath:      updateFilePath,
+			versionClient:       mockClient,
+		}
+
+		// Execute
+		err = checker.CheckLatestVersion()
+
+		// Verify
+		require.NoError(t, err)
+
+		// Verify that GetLatestVersion was not called
+		mockClient.AssertNotCalled(t, "GetLatestVersion")
+
+		// Verify the file wasn't modified
+		fileInfo, err := os.Stat(updateFilePath)
+		require.NoError(t, err)
+		assert.True(t, fileInfo.ModTime().Equal(freshTime), "File modification time should not have changed")
+	})
+
+	t.Run("error when stat fails", func(t *testing.T) {
+		// Setup
+		mockClient := setupMockVersionClient(t)
+		tempDir := createTempDir(t)
+
+		// Use a non-existent directory to cause a stat error
+		nonExistentDir := filepath.Join(tempDir, "non-existent")
+		updateFilePath := filepath.Join(nonExistentDir, "updates.json")
+
+		// Create the checker directly
+		checker := &defaultUpdateChecker{
+			instanceID:     testInstanceID,
+			currentVersion: testCurrentVersion,
+			updateFilePath: updateFilePath,
+			versionClient:  mockClient,
+		}
+
+		// Make the directory read-only to cause a stat error
+		err := os.Chmod(tempDir, 0000)
+		require.NoError(t, err)
+
+		// Ensure we restore permissions after the test
+		defer os.Chmod(tempDir, 0700)
+
+		// Execute
+		err = checker.CheckLatestVersion()
+
+		// Verify
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to stat update file")
+	})
+
+	t.Run("error when GetLatestVersion fails", func(t *testing.T) {
+		// Setup
+		mockClient := setupMockVersionClient(t)
+		tempDir := createTempDir(t)
+		updateFilePath := filepath.Join(tempDir, "updates.json")
+		instanceID := testInstanceID
+		currentVersion := testCurrentVersion
+		expectedError := errors.New("API error")
+
+		// Create the checker directly
+		checker := &defaultUpdateChecker{
+			instanceID:     instanceID,
+			currentVersion: currentVersion,
+			updateFilePath: updateFilePath,
+			versionClient:  mockClient,
+		}
+
+		// Mock client.GetLatestVersion to return an error
+		mockClient.On("GetLatestVersion", instanceID, currentVersion).Return("", expectedError)
+
+		// Execute
+		err := checker.CheckLatestVersion()
+
+		// Verify
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check for updates")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+// TestNotifyIfUpdateAvailable tests the notifyIfUpdateAvailable function
+func TestNotifyIfUpdateAvailable(t *testing.T) {
+	t.Run("no update available", func(_ *testing.T) {
+		// This test is a bit tricky since the function prints to stdout
+		// For simplicity, we'll just call it and make sure it doesn't panic
+		currentVersion := testCurrentVersion
+		latestVersion := testCurrentVersion
+
+		// This shouldn't panic
+		notifyIfUpdateAvailable(currentVersion, latestVersion)
+	})
+
+	t.Run("update available", func(_ *testing.T) {
+		// This test is a bit tricky since the function prints to stdout
+		// For simplicity, we'll just call it and make sure it doesn't panic
+		currentVersion := testCurrentVersion
+		latestVersion := testLatestVersion
+
+		// This shouldn't panic
+		notifyIfUpdateAvailable(currentVersion, latestVersion)
+	})
+}

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -1,0 +1,74 @@
+package updates
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// VersionClient is an interface for calling the update service API.
+type VersionClient interface {
+	GetLatestVersion(instanceID string, currentVersion string) (string, error)
+}
+
+// NewVersionClient creates a new instance of VersionClient.
+func NewVersionClient() VersionClient {
+	return &defaultVersionClient{
+		versionEndpoint: defaultVersionAPI,
+	}
+}
+
+type defaultVersionClient struct {
+	versionEndpoint string
+}
+
+const (
+	instanceIDHeader  = "X-Instance-ID"
+	userAgentHeader   = "User-Agent"
+	defaultVersionAPI = "https://updates.codegate.ai/api/v1/version"
+)
+
+// GetLatestVersion sends a GET request to the up2date API endpoint and returns the version from the response.
+// It returns an error if the request fails or if the response status code is not 200.
+func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersion string) (string, error) {
+	// Create a new request
+	req, err := http.NewRequest(http.MethodGet, d.versionEndpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	userAgent := fmt.Sprintf("toolhive/%s", currentVersion)
+	req.Header.Set(instanceIDHeader, instanceID)
+	req.Header.Set(userAgentHeader, userAgent)
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request to update API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if status code is 200
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("update API returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	// Read and parse the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse JSON response
+	var response struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	return response.Version, nil
+}

--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -1,0 +1,75 @@
+// Package versions provides version information for the ToolHive application.
+package versions
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"time"
+)
+
+const (
+	unknownStr = "unknown"
+)
+
+// Version information set by build using -ldflags
+var (
+	// Version is the current version of ToolHive
+	Version = "dev"
+	// Commit is the git commit hash of the build
+	//nolint:goconst // This is a placeholder for the commit hash
+	Commit = unknownStr
+	// BuildDate is the date when the binary was built
+	// nolint:goconst // This is a placeholder for the build date
+	BuildDate = unknownStr
+)
+
+// VersionInfo represents the version information
+type VersionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"build_date"`
+	GoVersion string `json:"go_version"`
+	Platform  string `json:"platform"`
+}
+
+// GetVersionInfo returns the version information
+func GetVersionInfo() VersionInfo {
+	// If version is still "dev", try to get it from build info
+	ver := Version
+	commit := Commit
+	buildDate := BuildDate
+
+	if ver == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			// Try to get version from build info
+			for _, setting := range info.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					if commit == unknownStr {
+						commit = setting.Value
+					}
+				case "vcs.time":
+					if buildDate == unknownStr {
+						buildDate = setting.Value
+					}
+				}
+			}
+		}
+	}
+
+	// Format the build date if it's a timestamp
+	if buildDate != unknownStr {
+		if t, err := time.Parse(time.RFC3339, buildDate); err == nil {
+			buildDate = t.Format("2006-01-02 15:04:05 MST")
+		}
+	}
+
+	return VersionInfo{
+		Version:   ver,
+		Commit:    commit,
+		BuildDate: buildDate,
+		GoVersion: runtime.Version(),
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
This PR introduces logic to check for new releases of ToolHive on startup. The logic work as follows:

1. On first run, an `updates.json` file is created alongside the config file. This contains an instance UUID, and the version returned from the API lookup.
2. On subsequent runs - check the file modification time of updates.json. a. If it's more than four hours old, call to the API, and update the updates.json file with the version returned. Notify the user if a new version is ready. b. If less than four hours old, compare the current version to the cached version from updates.json. Notify the user if an update is available. Skip calling the API.