### PR TITLE
Dynamically run npm/uv based MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ consistency, and security.
   - [Manage MCP servers](#manage-mcp-servers)
   - [Secrets management](#secrets-management)
   - [Run a custom MCP server](#run-a-custom-mcp-server)
+  - [Run MCP servers using protocol schemes](#run-mcp-servers-using-protocol-schemes)
 - [Advanced usage](#advanced-usage)
   - [Customize permissions](#customize-permissions)
   - [Run ToolHive in Kubernetes](#run-toolhive-in-kubernetes)
@@ -341,6 +342,44 @@ simplicity. When invoked:
   - **Server-sent events (SSE)** (`sse`):\
     ToolHive creates a reverse proxy on a random port that forwards requests to the
     container. This means the container itself does not directly expose any ports.
+
+### Run MCP servers using protocol schemes
+
+ToolHive supports running MCP servers directly from package managers using protocol schemes. This allows you to run MCP servers without having to build and publish Docker images first.
+
+Currently, two protocol schemes are supported:
+
+- **uvx://**: For Python-based MCP servers using the uv package manager
+- **npx://**: For Node.js-based MCP servers using npm
+
+For example, to run a Python-based MCP server:
+
+```bash
+thv run uvx://awslabs.core-mcp-server@latest
+```
+
+Or to run a Node.js-based MCP server:
+
+```bash
+thv run npx://pulumi/mcp-server@latest
+```
+
+When you use a protocol scheme, ToolHive will:
+
+1. Detect the protocol scheme and extract the package name
+2. Generate a Dockerfile based on the appropriate template
+3. Build a Docker image with the package installed
+4. Run the MCP server using the built image
+
+Note that in this case, you still might need to specify additional arguments like the
+transport method, volumes, and environment variables. So, the command might look like:
+
+```bash
+thv run --transport sse --name my-mcp-server --port 8080 uvx://some-sse-mcp-server@latest -- my-mcp-server-args
+```
+
+Read the documentation for the specific MCP server to see if it requires any additional
+arguments.
 
 ## Advanced usage
 

--- a/cmd/thv/app/run_protocol.go
+++ b/cmd/thv/app/run_protocol.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
 	"github.com/StacklokLabs/toolhive/pkg/container/templates"
@@ -67,10 +68,14 @@ func handleProtocolScheme(ctx context.Context, runtime rt.Runtime, serverOrImage
 		return "", fmt.Errorf("failed to write Dockerfile: %w", err)
 	}
 
+	//dynamically generate tag from timestamp
+	tag := time.Now().Format("20060102150405")
+
 	// Generate a unique image name based on the package name
-	imageName := fmt.Sprintf("toolhive-%s-%s:latest",
+	imageName := fmt.Sprintf("toolhivelocal/%s-%s:%s",
 		string(transportType),
-		strings.ReplaceAll(packageName, "/", "-"))
+		strings.ReplaceAll(packageName, "/", "-"),
+		tag)
 
 	// Log the build process
 	logDebug(debugMode, "Building Docker image for %s package: %s", transportType, packageName)

--- a/cmd/thv/app/run_protocol.go
+++ b/cmd/thv/app/run_protocol.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
+	"github.com/StacklokLabs/toolhive/pkg/container/templates"
+	"github.com/StacklokLabs/toolhive/pkg/logger"
+)
+
+// Protocol schemes
+const (
+	UVXScheme = "uvx://"
+	NPXScheme = "npx://"
+)
+
+// handleProtocolScheme checks if the serverOrImage string contains a protocol scheme (uvx:// or npx://)
+// and builds a Docker image for it if needed.
+// Returns the Docker image name to use and any error encountered.
+func handleProtocolScheme(ctx context.Context, runtime rt.Runtime, serverOrImage string, debugMode bool) (string, error) {
+	// Check if the serverOrImage starts with a protocol scheme
+	if !strings.HasPrefix(serverOrImage, UVXScheme) && !strings.HasPrefix(serverOrImage, NPXScheme) {
+		// No protocol scheme, return the original serverOrImage
+		return serverOrImage, nil
+	}
+
+	var transportType templates.TransportType
+	var packageName string
+
+	// Extract the transport type and package name based on the protocol scheme
+	if strings.HasPrefix(serverOrImage, UVXScheme) {
+		transportType = templates.TransportTypeUVX
+		packageName = strings.TrimPrefix(serverOrImage, UVXScheme)
+	} else if strings.HasPrefix(serverOrImage, NPXScheme) {
+		transportType = templates.TransportTypeNPX
+		packageName = strings.TrimPrefix(serverOrImage, NPXScheme)
+	} else {
+		return "", fmt.Errorf("unsupported protocol scheme: %s", serverOrImage)
+	}
+
+	// Create template data
+	templateData := templates.TemplateData{
+		MCPPackage: packageName,
+		MCPArgs:    []string{}, // No additional arguments for now
+	}
+
+	// Get the Dockerfile content
+	dockerfileContent, err := templates.GetDockerfileTemplate(transportType, templateData)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Dockerfile template: %w", err)
+	}
+
+	// Create a temporary directory for the Docker build context
+	tempDir, err := os.MkdirTemp("", "toolhive-docker-build-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Write the Dockerfile to the temporary directory
+	dockerfilePath := filepath.Join(tempDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfileContent), 0600); err != nil {
+		return "", fmt.Errorf("failed to write Dockerfile: %w", err)
+	}
+
+	// Generate a unique image name based on the package name
+	imageName := fmt.Sprintf("toolhive-%s-%s:latest",
+		string(transportType),
+		strings.ReplaceAll(packageName, "/", "-"))
+
+	// Log the build process
+	logDebug(debugMode, "Building Docker image for %s package: %s", transportType, packageName)
+	logDebug(debugMode, "Using Dockerfile:\n%s", dockerfileContent)
+
+	// Build the Docker image
+	logger.Log.Info(fmt.Sprintf("Building Docker image for %s package: %s", transportType, packageName))
+	if err := runtime.BuildImage(ctx, tempDir, imageName); err != nil {
+		return "", fmt.Errorf("failed to build Docker image: %w", err)
+	}
+	logger.Log.Info(fmt.Sprintf("Successfully built Docker image: %s", imageName))
+
+	return imageName, nil
+}

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -502,6 +502,15 @@ func (*Client) PullImage(_ context.Context, imageName string) error {
 	return nil
 }
 
+// BuildImage implements runtime.Runtime.
+func (*Client) BuildImage(_ context.Context, _, _ string) error {
+	// In Kubernetes, we don't build images directly within the cluster.
+	// Images should be built externally and pushed to a registry.
+	logger.Log.Warn("BuildImage is not supported in Kubernetes runtime. " +
+		"Images should be built externally and pushed to a registry.")
+	return fmt.Errorf("building images directly is not supported in Kubernetes runtime")
+}
+
 // RemoveContainer implements runtime.Runtime.
 func (c *Client) RemoveContainer(ctx context.Context, containerID string) error {
 	// In Kubernetes, we remove a container by deleting the statefulset

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -81,6 +81,9 @@ type Runtime interface {
 
 	// PullImage pulls an image from a registry
 	PullImage(ctx context.Context, image string) error
+
+	// BuildImage builds a Docker image from a Dockerfile in the specified context directory
+	BuildImage(ctx context.Context, contextDir, imageName string) error
 }
 
 // Monitor defines the interface for container monitoring

--- a/pkg/container/templates/npx.tmpl
+++ b/pkg/container/templates/npx.tmpl
@@ -1,0 +1,10 @@
+FROM node:22-slim
+
+# Set working directory
+WORKDIR /app
+
+# Run the MCP server using npx
+# The entrypoint will be constructed dynamically based on the package and arguments
+# Using the form: npx -- <pkg>[@<version>] [args...]
+# The -- separates npx options from the package name and arguments
+ENTRYPOINT ["npx", "--yes", "--", "{{.MCPPackage}}"{{range .MCPArgs}}, "{{.}}"{{end}}]

--- a/pkg/container/templates/templates.go
+++ b/pkg/container/templates/templates.go
@@ -1,0 +1,78 @@
+// Package templates provides utilities for generating Dockerfile templates
+// based on different transport types (uvx, npx).
+package templates
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed *.tmpl
+var templateFS embed.FS
+
+// TemplateData represents the data to be passed to the Dockerfile template.
+type TemplateData struct {
+	// MCPPackage is the name of the MCP package to run.
+	MCPPackage string
+	// MCPArgs are the arguments to pass to the MCP package.
+	MCPArgs []string
+}
+
+// TransportType represents the type of transport to use.
+type TransportType string
+
+const (
+	// TransportTypeUVX represents the uvx transport.
+	TransportTypeUVX TransportType = "uvx"
+	// TransportTypeNPX represents the npx transport.
+	TransportTypeNPX TransportType = "npx"
+)
+
+// GetDockerfileTemplate returns the Dockerfile template for the specified transport type.
+func GetDockerfileTemplate(transportType TransportType, data TemplateData) (string, error) {
+	var templateName string
+
+	// Determine the template name based on the transport type
+	switch transportType {
+	case TransportTypeUVX:
+		templateName = "uvx.tmpl"
+	case TransportTypeNPX:
+		templateName = "npx.tmpl"
+	default:
+		return "", fmt.Errorf("unsupported transport type: %s", transportType)
+	}
+
+	// Read the template file
+	tmplContent, err := templateFS.ReadFile(templateName)
+	if err != nil {
+		return "", fmt.Errorf("failed to read template file: %w", err)
+	}
+
+	// Parse the template
+	tmpl, err := template.New(templateName).Parse(string(tmplContent))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	// Execute the template with the provided data
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// ParseTransportType parses a string into a transport type.
+func ParseTransportType(s string) (TransportType, error) {
+	switch s {
+	case "uvx":
+		return TransportTypeUVX, nil
+	case "npx":
+		return TransportTypeNPX, nil
+	default:
+		return "", fmt.Errorf("unsupported transport type: %s", s)
+	}
+}

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -1,0 +1,115 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetDockerfileTemplate(t *testing.T) {
+	tests := []struct {
+		name          string
+		transportType TransportType
+		data          TemplateData
+		wantContains  []string
+		wantErr       bool
+	}{
+		{
+			name:          "UVX transport",
+			transportType: TransportTypeUVX,
+			data: TemplateData{
+				MCPPackage: "example-package",
+				MCPArgs:    []string{"--arg1", "--arg2", "value"},
+			},
+			wantContains: []string{
+				"FROM python:3.12-slim",
+				"RUN pip install uv",
+				"ENTRYPOINT [\"uvx\", \"example-package\", \"--arg1\", \"--arg2\", \"value\"]",
+			},
+			wantErr: false,
+		},
+		{
+			name:          "NPX transport",
+			transportType: TransportTypeNPX,
+			data: TemplateData{
+				MCPPackage: "example-package",
+				MCPArgs:    []string{"--arg1", "--arg2", "value"},
+			},
+			wantContains: []string{
+				"FROM node:22-slim",
+				"ENTRYPOINT [\"npx\", \"--yes\", \"--\", \"example-package\", \"--arg1\", \"--arg2\", \"value\"]",
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Unsupported transport",
+			transportType: "unsupported",
+			data: TemplateData{
+				MCPPackage: "example-package",
+				MCPArgs:    []string{"--arg1", "--arg2", "value"},
+			},
+			wantContains: nil,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetDockerfileTemplate(tt.transportType, tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDockerfileTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("GetDockerfileTemplate() = %v, want to contain %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTransportType(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       string
+		want    TransportType
+		wantErr bool
+	}{
+		{
+			name:    "UVX transport",
+			s:       "uvx",
+			want:    TransportTypeUVX,
+			wantErr: false,
+		},
+		{
+			name:    "NPX transport",
+			s:       "npx",
+			want:    TransportTypeNPX,
+			wantErr: false,
+		},
+		{
+			name:    "Unsupported transport",
+			s:       "unsupported",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTransportType(tt.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTransportType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseTransportType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/container/templates/uvx.tmpl
+++ b/pkg/container/templates/uvx.tmpl
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+# Install uv package manager
+RUN pip install uv
+
+# Set working directory
+WORKDIR /app
+
+# Run the MCP server using uvx (alias for uv tool run)
+# The entrypoint will be constructed dynamically based on the package and arguments
+ENTRYPOINT ["uvx", "{{.MCPPackage}}"{{range .MCPArgs}}, "{{.}}"{{end}}]

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -73,6 +73,10 @@ func (*mockRuntime) PullImage(_ context.Context, _ string) error {
 	return nil
 }
 
+func (*mockRuntime) BuildImage(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (*mockRuntime) Name() string {
 	return "mock"
 }


### PR DESCRIPTION
This allows ToolHive to dynamically run uv or npm based MCP servers without requiring them to be containerized. The premise is that we're able to detect if you use a transport protocol prefix to the MCP reference, and build a container image dynamically out of that. This way, you don't need to install `uv` or `npm` in your host to run MCP servers.

Do `thv run npx://<NPM package without the @ prefix>` or `thv run uvx://<package name>` to run them.

Related-to: #160 
