### PR TITLE
Rename `stdio` permission profile to `none`

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -56,8 +56,8 @@ func init() {
 	runCmd.Flags().StringVar(
 		&runPermissionProfile,
 		"permission-profile",
-		"stdio",
-		"Permission profile to use (stdio, network, or path to JSON file)",
+		permissions.ProfileNone,
+		"Permission profile to use (none, network, or path to JSON file)",
 	)
 	runCmd.Flags().StringArrayVarP(
 		&runEnv,

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -26,7 +26,7 @@ thv run [flags] SERVER_OR_IMAGE [-- ARGS...]
       --oidc-client-id string       OIDC client ID
       --oidc-issuer string          OIDC issuer URL (e.g., https://accounts.google.com)
       --oidc-jwks-url string        URL to fetch the JWKS from
-      --permission-profile string   Permission profile to use (stdio, network, or path to JSON file) (default "stdio")
+      --permission-profile string   Permission profile to use (none, network, or path to JSON file) (default "none")
       --port int                    Port for the HTTP proxy to listen on (host port)
       --secret stringArray          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
       --target-host string          Host to forward traffic to (only applicable to SSE transport) (default "localhost")

--- a/pkg/permissions/profile.go
+++ b/pkg/permissions/profile.go
@@ -11,6 +11,14 @@ import (
 	"strings"
 )
 
+// Built-in permission profile names
+const (
+	// ProfileNone is the name of the built-in profile with no permissions
+	ProfileNone = "none"
+	// ProfileNetwork is the name of the built-in profile with network permissions
+	ProfileNetwork = "network"
+)
+
 // Profile represents a permission profile for a container
 type Profile struct {
 	// Read is a list of mount declarations that the container can read from
@@ -83,8 +91,8 @@ func FromFile(path string) (*Profile, error) {
 	return &profile, nil
 }
 
-// BuiltinStdioProfile returns the built-in stdio profile
-func BuiltinStdioProfile() *Profile {
+// BuiltinNoneProfile returns the built-in profile with no permissions
+func BuiltinNoneProfile() *Profile {
 	return &Profile{
 		Read:  []MountDeclaration{},
 		Write: []MountDeclaration{},

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -203,7 +203,7 @@ func (c *RunConfig) ParsePermissionProfile() (*RunConfig, error) {
 	var err error
 
 	switch c.PermissionProfileNameOrPath {
-	case permissions.ProfileNone:
+	case permissions.ProfileNone, "stdio":
 		permProfile = permissions.BuiltinNoneProfile()
 	case permissions.ProfileNetwork:
 		permProfile = permissions.BuiltinNetworkProfile()

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -203,10 +203,9 @@ func (c *RunConfig) ParsePermissionProfile() (*RunConfig, error) {
 	var err error
 
 	switch c.PermissionProfileNameOrPath {
-	//nolint:goconst // Let's do this later
-	case "stdio":
-		permProfile = permissions.BuiltinStdioProfile()
-	case "network":
+	case permissions.ProfileNone:
+		permProfile = permissions.BuiltinNoneProfile()
+	case permissions.ProfileNetwork:
 		permProfile = permissions.BuiltinNetworkProfile()
 	default:
 		// Try to load from file

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -212,14 +212,14 @@ func TestRunConfig_ParsePermissionProfile(t *testing.T) {
 			expectError:       true,
 		},
 		{
-			name:                "Stdio built-in profile",
-			profileNameOrPath:   "stdio",
+			name:                "None built-in profile",
+			profileNameOrPath:   permissions.ProfileNone,
 			expectError:         false,
-			expectedProfileType: "stdio",
+			expectedProfileType: "none",
 		},
 		{
 			name:                "Network built-in profile",
-			profileNameOrPath:   "network",
+			profileNameOrPath:   permissions.ProfileNetwork,
 			expectError:         false,
 			expectedProfileType: "network",
 		},
@@ -289,10 +289,10 @@ func TestRunConfig_ParsePermissionProfile(t *testing.T) {
 				assert.NotNil(t, config.PermissionProfile, "PermissionProfile should be set")
 
 				switch tc.expectedProfileType {
-				case "stdio":
-					// For stdio profile, check that network outbound is not allowed
+				case "none":
+					// For none profile, check that network outbound is not allowed
 					assert.False(t, config.PermissionProfile.Network.Outbound.InsecureAllowAll,
-						"Stdio profile should not allow all outbound network connections")
+						"None profile should not allow all outbound network connections")
 				case "network":
 					// For network profile, check that network outbound is allowed
 					assert.True(t, config.PermissionProfile.Network.Outbound.InsecureAllowAll,
@@ -341,7 +341,7 @@ func TestRunConfig_ProcessVolumeMounts(t *testing.T) {
 			name: "Volumes without permission profile but with profile name",
 			config: &RunConfig{
 				Volumes:                     []string{"/host:/container"},
-				PermissionProfileNameOrPath: "stdio",
+				PermissionProfileNameOrPath: permissions.ProfileNone,
 			},
 			expectError:         false,
 			expectedReadMounts:  0,
@@ -351,7 +351,7 @@ func TestRunConfig_ProcessVolumeMounts(t *testing.T) {
 			name: "Read-only volume with existing profile",
 			config: &RunConfig{
 				Volumes:           []string{"/host:/container:ro"},
-				PermissionProfile: permissions.BuiltinStdioProfile(),
+				PermissionProfile: permissions.BuiltinNoneProfile(),
 			},
 			expectError:         false,
 			expectedReadMounts:  1,
@@ -361,7 +361,7 @@ func TestRunConfig_ProcessVolumeMounts(t *testing.T) {
 			name: "Read-write volume with existing profile",
 			config: &RunConfig{
 				Volumes:           []string{"/host:/container"},
-				PermissionProfile: permissions.BuiltinStdioProfile(),
+				PermissionProfile: permissions.BuiltinNoneProfile(),
 			},
 			expectError:         false,
 			expectedReadMounts:  0,
@@ -375,7 +375,7 @@ func TestRunConfig_ProcessVolumeMounts(t *testing.T) {
 					"/host2:/container2",
 					"/host3:/container3:ro",
 				},
-				PermissionProfile: permissions.BuiltinStdioProfile(),
+				PermissionProfile: permissions.BuiltinNoneProfile(),
 			},
 			expectError:         false,
 			expectedReadMounts:  2,
@@ -385,7 +385,7 @@ func TestRunConfig_ProcessVolumeMounts(t *testing.T) {
 			name: "Invalid volume format",
 			config: &RunConfig{
 				Volumes:           []string{"invalid:format:with:too:many:colons"},
-				PermissionProfile: permissions.BuiltinStdioProfile(),
+				PermissionProfile: permissions.BuiltinNoneProfile(),
 			},
 			expectError: true,
 		},
@@ -804,7 +804,7 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 	volumes := []string{"/host:/container"}
 	secretsList := []string{"secret1,target=ENV_VAR1"}
 	authzConfigPath := "/path/to/authz.json"
-	permissionProfile := "stdio"
+	permissionProfile := permissions.ProfileNone
 	targetHost := "localhost"
 	oidcIssuer := "https://issuer.example.com"
 	oidcAudience := "test-audience"


### PR DESCRIPTION
The built-in permission profile was misnamed, `none` is a better name
for it, since it provides full isolation and no permissions.

This also sets the permission profile names as constants.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
