### PR TITLE
Use semver comparison for update checking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/exp/jsonrpc2 v0.0.0-20250305212735-054e65f0b394
+	golang.org/x/mod v0.22.0
 	golang.org/x/sync v0.13.0
 	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ golang.org/x/exp/jsonrpc2 v0.0.0-20250305212735-054e65f0b394 h1:nGndmxp2Ri3USfp0
 golang.org/x/exp/jsonrpc2 v0.0.0-20250305212735-054e65f0b394/go.mod h1:nPUl66QnKRf99UZqZolP9+aV0hDQ39vdswdEZj6OKZA=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -12,7 +12,7 @@ import (
 // ParseSecretParameters parses the secret parameters from the command line,
 // fetches them from the secrets manager, and returns a map of secrets and
 // their environment variable names.
-func ParseSecretParameters(parameters []string, secretsManager secrets.Manager) (map[string]string, error) {
+func ParseSecretParameters(parameters []string, secretsManager secrets.Provider) (map[string]string, error) {
 	secretVariables := make(map[string]string, len(parameters))
 	for _, param := range parameters {
 		parameter, err := secrets.ParseSecretParameter(param)

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -242,7 +242,7 @@ func (c *RunConfig) WithEnvironmentVariables(envVarStrings []string) (*RunConfig
 }
 
 // WithSecrets processes secrets and adds them to environment variables
-func (c *RunConfig) WithSecrets(secretManager secrets.Manager) (*RunConfig, error) {
+func (c *RunConfig) WithSecrets(secretManager secrets.Provider) (*RunConfig, error) {
 	if len(c.Secrets) == 0 {
 		return c, nil // No secrets to process
 	}

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -115,7 +115,7 @@ func (e *EncryptedManager) updateFile() error {
 }
 
 // NewEncryptedManager creates an instance of EncryptedManager.
-func NewEncryptedManager(filePath string, key []byte) (Manager, error) {
+func NewEncryptedManager(filePath string, key []byte) (Provider, error) {
 	if len(key) == 0 {
 		return nil, errors.New("key cannot be empty")
 	}

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -32,7 +32,7 @@ const (
 var ErrUnknownManagerType = errors.New("unknown secret manager type")
 
 // CreateSecretManager creates the specified type of secret manager.
-func CreateSecretManager(managerType ProviderType) (Manager, error) {
+func CreateSecretManager(managerType ProviderType) (Provider, error) {
 	switch managerType {
 	case EncryptedType:
 		password, err := GetSecretsPassword()

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -9,8 +9,8 @@ import (
 // regex to extract name and target from secret parameter, e.g. "name,target=target"
 var secretParamRegex = regexp.MustCompile(`^([^,]+),target=(.+)$`)
 
-// Manager describes a type which can manage secrets.
-type Manager interface {
+// Provider describes a type which can manage secrets.
+type Provider interface {
 	GetSecret(name string) (string, error)
 	SetSecret(name, value string) error
 	DeleteSecret(name string) error

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/google/uuid"
+	"golang.org/x/mod/semver"
 
 	"github.com/StacklokLabs/toolhive/pkg/versions"
 )
@@ -90,6 +91,8 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 		return nil
 	}
 
+	fmt.Println("checking for updates...")
+
 	// If the update file is stale or does not exist - get the latest version
 	// from the API.
 	latestVersion, err := d.versionClient.GetLatestVersion(d.instanceID, d.currentVersion)
@@ -121,8 +124,7 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 }
 
 func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
-	// TODO: Consider using semver logic in future.
-	if currentVersion != latestVersion {
-		fmt.Printf("A new version of ToolHive is available: %s\n", latestVersion)
+	if semver.Compare(currentVersion, latestVersion) < 0 {
+		fmt.Printf("A new version of ToolHive is available: %s\n. Currently running%s\n", latestVersion, currentVersion)
 	}
 }

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -125,6 +125,6 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 
 func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
 	if semver.Compare(currentVersion, latestVersion) < 0 {
-		fmt.Printf("A new version of ToolHive is available: %s\n. Currently running%s\n", latestVersion, currentVersion)
+		fmt.Printf("A new version of ToolHive is available: %s\nCurrently running: %s\n", latestVersion, currentVersion)
 	}
 }

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -30,7 +30,7 @@ const (
 	defaultVersionAPI = "https://updates.codegate.ai/api/v1/version"
 )
 
-// GetLatestVersion sends a GET request to the up2date API endpoint and returns the version from the response.
+// GetLatestVersion sends a GET request to the update API endpoint and returns the version from the response.
 // It returns an error if the request fails or if the response status code is not 200.
 func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersion string) (string, error) {
 	// Create a new request


### PR DESCRIPTION
Some other refactoring, including renaming secrets.Manager to secrets.Provider for the sake of consistency.