### PR TITLE
Fix command processing

### DIFF
--- a/cmd/thv/app/run_common.go
+++ b/cmd/thv/app/run_common.go
@@ -133,6 +133,7 @@ func detachProcess(cmd *cobra.Command, options *runner.RunConfig) error {
 	// Add the image and any arguments
 	detachedArgs = append(detachedArgs, options.Image)
 	if len(options.CmdArgs) > 0 {
+		detachedArgs = append(detachedArgs, "--")
 		detachedArgs = append(detachedArgs, options.CmdArgs...)
 	}
 


### PR DESCRIPTION
Cobra was swalling the command line arguments, so I resorted back to
using os.Args. Subsequently, we were missing the `--` from the container
run in detached mode. This should fix things up in a way that containers
now get the right arguments.

Closes: #170
Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
