### PR TITLE
Add Kubernetes RBAC resources for toolhive

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,46 @@
+# Kubernetes Deployment
+
+This directory contains Kubernetes manifests for deploying toolhive in a Kubernetes cluster.
+
+Note that this support is experimental as of now since we're still working on more thorough support.
+If you're interested in contributing to this or want to see more extensive Kubernetes support, please reach out to us on our [Discord](https://discord.gg/stacklok).
+We'd love to hear your feedback and suggestions!
+
+## Files
+
+- `thv.yaml`: Contains the StatefulSet and Service for the toolhive application
+- `ingress.yaml`: Contains an Ingress resource for routing HTTP traffic to toolhive
+- `rbac.yaml`: Contains RBAC resources (ServiceAccount, Role, RoleBinding) for namespace-scoped deployments
+- `namespace.yaml`: Contains a Namespace resource for deploying toolhive in a dedicated namespace
+
+## Deployment Options
+
+### Default Namespace Deployment
+
+For deploying toolhive in the default namespace:
+
+```bash
+kubectl apply -f rbac.yaml
+kubectl apply -f thv.yaml
+kubectl apply -f ingress.yaml  # Optional, if you need ingress
+```
+
+### Dedicated Namespace Deployment
+
+For deploying toolhive in a dedicated namespace:
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f rbac.yaml -n toolhive-deployment
+kubectl apply -f thv.yaml -n toolhive-deployment
+kubectl apply -f ingress.yaml -n toolhive-deployment  # Optional, if you need ingress
+```
+
+## Customization
+
+You may need to customize these manifests based on your specific requirements:
+
+1. Update the image reference in `thv.yaml` if you're using a custom image
+2. Modify resource limits and requests in `thv.yaml` based on your workload
+3. Adjust the RBAC permissions in `rbac.yaml` if needed
+4. Configure the Ingress resource in `ingress.yaml` to match your ingress controller and domain

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolhive-deployment
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive

--- a/deploy/k8s/rbac.yaml
+++ b/deploy/k8s/rbac.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: toolhive
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: toolhive
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+rules:
+  # StatefulSet management
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "apply"]
+  
+  # Service management
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "apply"]
+  
+  # Pod management
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  
+  # Pod logs
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  
+  # Pod attach (for attaching to containers)
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: toolhive
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+subjects:
+- kind: ServiceAccount
+  name: toolhive
+roleRef:
+  kind: Role
+  name: toolhive
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/k8s/thv.yaml
+++ b/deploy/k8s/thv.yaml
@@ -18,6 +18,7 @@ spec:
         app: toolhive
         app.kubernetes.io/name: toolhive
     spec:
+      serviceAccountName: toolhive
       containers:
       - name: toolhive
         image: ko://github.com/StacklokLabs/toolhive/cmd


### PR DESCRIPTION
This commit adds dedicated RBAC resources for toolhive:

- Created a ServiceAccount for toolhive
- Created a Role with the necessary permissions for StatefulSets, Services, Pods, and Pod attachments
- Created a RoleBinding to bind the Role to the ServiceAccount
- Updated the StatefulSet in thv.yaml to use the new ServiceAccount
- Added a namespace.yaml file for deploying toolhive in a dedicated namespace
- Added a README.md with deployment instructions and options

These changes improve security by replacing the overly permissive cluster-admin role
with a more restricted role that has only the necessary permissions for toolhive to function.

Closes: #102
