### PR TITLE
Harden the comparing for the version command

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "commit=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%ct)" >> $GITHUB_OUTPUT
-          echo "version=$(git describe --tags --always --dirty | cut -c2-)" >> $GITHUB_OUTPUT
+          echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
           echo "tree-state=$(if git diff --quiet; then echo "clean"; else echo "dirty"; fi)" >> $GITHUB_OUTPUT
   release:
     needs:

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -126,8 +126,16 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 }
 
 func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
-	// Ensure both versions have the 'v' prefix for proper semantic version comparison.
-	if semver.Compare(semver.Canonical(currentVersion), semver.Canonical(latestVersion)) < 0 {
+	current, latest := currentVersion, latestVersion
+	// Ensure both versions have the 'v' prefix for proper semantic version comparison
+	if !semver.IsValid(current) {
+		current = fmt.Sprintf("v%s", current)
+	}
+	if !semver.IsValid(latest) {
+		latest = fmt.Sprintf("v%s", latest)
+	}
+	// Compare the versions ensuring their canonical forms
+	if semver.Compare(semver.Canonical(current), semver.Canonical(latest)) < 0 {
 		fmt.Printf("A new version of ToolHive is available: %s\nCurrently running: %s\n", latestVersion, currentVersion)
 	}
 }


### PR DESCRIPTION
Well, apparently this manifested another thing we had which was - 
* We were stripping out the `v` when populating the version env var (thus why we were hitting this issue in the first place)
* Canonicalising something like `0.0.13` is apparently an empty string, so this way now we'll ensure the v is always present if the form is not valid.