### PR TITLE
authz: Enhance Cedar authorization framework

### DIFF
--- a/pkg/authz/cedar_entity.go
+++ b/pkg/authz/cedar_entity.go
@@ -84,6 +84,7 @@ func (*EntityFactory) CreateResourceEntity(
 // CreateEntitiesForRequest creates entities for a specific authorization request.
 func (f *EntityFactory) CreateEntitiesForRequest(
 	principal, action, resource string,
+	claimsMap map[string]interface{},
 	attributes map[string]interface{},
 ) (cedar.EntityMap, error) {
 	// Parse principal, action, and resource
@@ -106,7 +107,7 @@ func (f *EntityFactory) CreateEntitiesForRequest(
 	entities := make(cedar.EntityMap)
 
 	// Create principal entity
-	principalUID, principalEntity := f.CreatePrincipalEntity(principalType, principalID, nil)
+	principalUID, principalEntity := f.CreatePrincipalEntity(principalType, principalID, claimsMap)
 	entities[principalUID] = principalEntity
 
 	// Create action entity


### PR DESCRIPTION
This commit enhances the Cedar authorization framework to properly handle
JWT claims and tool arguments:

1. JWT claims are now added to the principal entity and are accessible via
   `principal.claim_*` in Cedar policies.

2. Tool arguments are now added to the resource entity and are accessible via
   `resource.arg_*` in Cedar policies.

3. Both claims and arguments are also available in the context and are
   accessible via `context.claim_*` and `context.arg_*` in Cedar policies.

4. Updated the documentation to reflect these changes and provide examples
   of both entity-based and context-based access to claims and arguments.

5. Updated the tests to properly use the new `CreateEntitiesForRequest`
   function signature, which now takes both `claimsMap` and `attributes`
   parameters.

These changes make the authorization framework more flexible and powerful,
allowing for more sophisticated authorization policies that can leverage
both JWT claims and tool arguments.
