### PR TITLE
refactor: remove unused response channel

### DIFF
--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -64,9 +64,8 @@ type HTTPSSEProxy struct {
 	pendingMessages []*ssecommon.PendingSSEMessage
 	pendingMutex    sync.Mutex
 
-	// Message channels
-	messageCh  chan jsonrpc2.Message
-	responseCh chan jsonrpc2.Message
+	// Message channel
+	messageCh chan jsonrpc2.Message
 }
 
 // NewHTTPSSEProxy creates a new HTTP SSE proxy for transports.
@@ -77,7 +76,6 @@ func NewHTTPSSEProxy(port int, containerName string, middlewares ...types.Middle
 		containerName:   containerName,
 		shutdownCh:      make(chan struct{}),
 		messageCh:       make(chan jsonrpc2.Message, 100),
-		responseCh:      make(chan jsonrpc2.Message, 100),
 		sseClients:      make(map[string]*ssecommon.SSEClient),
 		pendingMessages: []*ssecommon.PendingSSEMessage{},
 	}
@@ -148,11 +146,6 @@ func (p *HTTPSSEProxy) GetMessageChannel() chan jsonrpc2.Message {
 	return p.messageCh
 }
 
-// GetResponseChannel returns the channel for receiving messages from the destination.
-func (p *HTTPSSEProxy) GetResponseChannel() <-chan jsonrpc2.Message {
-	return p.responseCh
-}
-
 // SendMessageToDestination sends a message to the destination via the message channel.
 func (p *HTTPSSEProxy) SendMessageToDestination(msg jsonrpc2.Message) error {
 	select {
@@ -162,18 +155,6 @@ func (p *HTTPSSEProxy) SendMessageToDestination(msg jsonrpc2.Message) error {
 	default:
 		// Channel is full or closed
 		return fmt.Errorf("failed to send message to destination")
-	}
-}
-
-// SendResponseMessage sends a message to the response channel.
-func (p *HTTPSSEProxy) SendResponseMessage(msg jsonrpc2.Message) error {
-	select {
-	case p.responseCh <- msg:
-		// Message sent successfully
-		return nil
-	default:
-		// Channel is full or closed
-		return fmt.Errorf("failed to send message to response channel")
 	}
 }
 

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -140,12 +140,6 @@ func (*TransparentProxy) GetMessageChannel() chan jsonrpc2.Message {
 	return nil
 }
 
-// GetResponseChannel returns the channel for receiving messages from the destination.
-// This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) GetResponseChannel() <-chan jsonrpc2.Message {
-	return nil
-}
-
 // SendMessageToDestination sends a message to the destination.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
 func (*TransparentProxy) SendMessageToDestination(_ jsonrpc2.Message) error {
@@ -156,10 +150,4 @@ func (*TransparentProxy) SendMessageToDestination(_ jsonrpc2.Message) error {
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
 func (*TransparentProxy) ForwardResponseToClients(_ context.Context, _ jsonrpc2.Message) error {
 	return fmt.Errorf("ForwardResponseToClients not implemented for TransparentProxy")
-}
-
-// SendResponseMessage sends a message to the response channel.
-// This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) SendResponseMessage(_ jsonrpc2.Message) error {
-	return fmt.Errorf("SendResponseMessage not implemented for TransparentProxy")
 }

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -427,11 +427,6 @@ func (t *StdioTransport) parseAndForwardJSONRPC(ctx context.Context, line string
 	if err := t.httpProxy.ForwardResponseToClients(ctx, msg); err != nil {
 		logger.Log.Error(fmt.Sprintf("Error forwarding to SSE clients: %v", err))
 	}
-
-	// Send to the response channel
-	if err := t.httpProxy.SendResponseMessage(msg); err != nil {
-		logger.Log.Error(fmt.Sprintf("Error sending to response channel: %v", err))
-	}
 }
 
 // sendMessageToContainer sends a JSON-RPC message to the container.

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -83,17 +83,11 @@ type Proxy interface {
 	// GetMessageChannel returns the channel for messages to/from the destination.
 	GetMessageChannel() chan jsonrpc2.Message
 
-	// GetResponseChannel returns the channel for receiving messages from the destination.
-	GetResponseChannel() <-chan jsonrpc2.Message
-
 	// SendMessageToDestination sends a message to the destination.
 	SendMessageToDestination(msg jsonrpc2.Message) error
 
 	// ForwardResponseToClients forwards a response from the destination to clients.
 	ForwardResponseToClients(ctx context.Context, msg jsonrpc2.Message) error
-
-	// SendResponseMessage sends a message to the response channel.
-	SendResponseMessage(msg jsonrpc2.Message) error
 }
 
 // Config contains configuration options for a transport.


### PR DESCRIPTION
This commit removes the unused response channel from the transport proxy
implementation. The response channel was being written to in the
parseAndForwardJSONRPC function but was never consumed anywhere in the
codebase.

This change prevents potential memory issues from the channel filling up
and eliminates unnecessary error logs when the channel becomes full,
while maintaining the primary message flow between clients and containers.
