### PR TITLE
feat(authz): Add YAML support for CedarConfig

### DIFF
--- a/docs/authz.md
+++ b/docs/authz.md
@@ -14,7 +14,7 @@ authorization framework consists of the following components:
    if a request is authorized.
 2. **Authorization middleware**: An HTTP middleware that extracts information
    from MCP requests and uses the Cedar Authorizer to authorize the request.
-3. **Configuration**: A JSON configuration file that specifies the Cedar
+3. **Configuration**: A configuration file (JSON or YAML) that specifies the Cedar
    policies and entities.
 
 The framework integrates with the existing JWT authentication middleware to
@@ -45,7 +45,9 @@ steps:
 
 ### Create an authorization configuration file
 
-Create a JSON file with the following structure:
+Create a configuration file (JSON or YAML) with the following structure:
+
+#### JSON Format
 
 ```json
 {
@@ -60,6 +62,19 @@ Create a JSON file with the following structure:
     "entities_json": "[]"
   }
 }
+```
+
+#### YAML Format
+
+```yaml
+version: "1.0"
+type: cedarv1
+cedar:
+  policies:
+    - 'permit(principal, action == Action::"call_tool", resource == Tool::"weather");'
+    - 'permit(principal, action == Action::"get_prompt", resource == Prompt::"greeting");'
+    - 'permit(principal, action == Action::"read_resource", resource == Resource::"data");'
+  entities_json: "[]"
 ```
 
 The configuration file has the following fields:
@@ -79,10 +94,10 @@ To start an MCP server with authorization, use the `--authz-config` flag:
 thv run --transport sse --name my-mcp-server --port 8080 --authz-config /path/to/authz-config.json my-mcp-server-image:latest -- my-mcp-server-args
 ```
 
-You can also use the `registry run` command with the same flag:
+Or with a YAML configuration:
 
 ```bash
-thv registry run my-mcp-server --authz-config /path/to/authz-config.json -- my-mcp-server-args
+thv run --transport sse --name my-mcp-server --port 8080 --authz-config /path/to/authz-config.yaml my-mcp-server-image:latest -- my-mcp-server-args
 ```
 
 ## Writing Cedar policies
@@ -281,7 +296,7 @@ of the configuration file:
   "type": "cedarv1",
   "cedar": {
     "policies": [
-      "permit(principal, action == Action::"call_tool", resource) when { resource.owner == principal.claim_sub };"
+      "permit(principal, action == Action::\"call_tool\", resource) when { resource.owner == principal.claim_sub };"
     ],
     "entities_json": "[
       {

--- a/pkg/authz/config.go
+++ b/pkg/authz/config.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
 )
 
 // ConfigType represents the type of authorization configuration.
@@ -19,26 +23,27 @@ const (
 // Config represents the authorization configuration.
 type Config struct {
 	// Version is the version of the configuration format.
-	Version string `json:"version"`
+	Version string `json:"version" yaml:"version"`
 
 	// Type is the type of authorization configuration.
-	Type ConfigType `json:"type"`
+	Type ConfigType `json:"type" yaml:"type"`
 
 	// Cedar is the Cedar-specific configuration.
 	// This is only used when Type is ConfigTypeCedarV1.
-	Cedar *CedarConfig `json:"cedar,omitempty"`
+	Cedar *CedarConfig `json:"cedar,omitempty" yaml:"cedar,omitempty"`
 }
 
 // CedarConfig represents the Cedar-specific authorization configuration.
 type CedarConfig struct {
 	// Policies is a list of Cedar policy strings
-	Policies []string `json:"policies"`
+	Policies []string `json:"policies" yaml:"policies"`
 
 	// EntitiesJSON is the JSON string representing Cedar entities
-	EntitiesJSON string `json:"entities_json"`
+	EntitiesJSON string `json:"entities_json" yaml:"entities_json"`
 }
 
 // LoadConfig loads the authorization configuration from a file.
+// It supports both JSON and YAML formats, detected by file extension.
 //
 //nolint:gosec // This is intentionally loading a file specified by the user
 func LoadConfig(path string) (*Config, error) {
@@ -48,10 +53,24 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read authorization configuration file: %w", err)
 	}
 
-	// Parse the JSON
+	// Determine the file format based on extension
 	var config Config
-	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse authorization configuration file: %w", err)
+	ext := strings.ToLower(filepath.Ext(path))
+
+	// Parse the file based on its format
+	switch ext {
+	case ".yaml", ".yml":
+		// Parse YAML
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse YAML authorization configuration file: %w", err)
+		}
+	case ".json", "":
+		// Parse JSON (default if no extension)
+		if err := json.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON authorization configuration file: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported file format: %s (supported formats: .json, .yaml, .yml)", ext)
 	}
 
 	// Validate the configuration


### PR DESCRIPTION
This change adds support for reading CedarConfig from YAML files in addition to
the existing JSON support. The implementation includes:

1. Adding YAML tags to the Config and CedarConfig structs
2. Modifying the LoadConfig function to detect file format based on extension
3. Updating documentation to reflect YAML support

This enhancement provides more flexibility for users who prefer YAML over JSON
for configuration files.
