### PR TITLE
registry: Add target port to Server struct

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -148,6 +148,9 @@ func printTextServerInfo(name string, server *registry.Server) {
 	fmt.Printf("Image: %s\n", server.Image)
 	fmt.Printf("Description: %s\n", server.Description)
 	fmt.Printf("Transport: %s\n", server.Transport)
+	if server.Transport == "sse" && server.TargetPort > 0 {
+		fmt.Printf("Target Port: %d\n", server.TargetPort)
+	}
 	fmt.Printf("Repository URL: %s\n", server.RepositoryURL)
 	fmt.Printf("Popularity: %d stars, %d pulls\n", server.Metadata.Stars, server.Metadata.Pulls)
 	fmt.Printf("Last Updated: %s\n", server.Metadata.LastUpdated)

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -236,6 +236,12 @@ func applyRegistrySettings(
 			runTransport, server.Transport)
 	}
 
+	// Use registry target port if not overridden and transport is SSE
+	if !cmd.Flags().Changed("target-port") && server.Transport == "sse" && server.TargetPort > 0 {
+		logDebug(debugMode, "Using registry target port: %d", server.TargetPort)
+		runTargetPort = server.TargetPort
+	}
+
 	// Process environment variables from registry
 	// This will be merged with command-line env vars in configureRunConfig
 	envVarStrings := processEnvironmentVariables(server.EnvVars, runEnv, config.Secrets, debugMode)

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -16,10 +16,12 @@ type Registry struct {
 
 // Server represents an MCP server in the registry
 type Server struct {
-	Name          string               `json:"name,omitempty"`
-	Image         string               `json:"image"`
-	Description   string               `json:"description"`
-	Transport     string               `json:"transport"`
+	Name        string `json:"name,omitempty"`
+	Image       string `json:"image"`
+	Description string `json:"description"`
+	Transport   string `json:"transport"`
+	// TargetPort is the port for the container to expose (only applicable to SSE transport)
+	TargetPort    int                  `json:"target_port,omitempty"`
 	Permissions   *permissions.Profile `json:"permissions"`
 	Tools         []string             `json:"tools"`
 	EnvVars       []*EnvVar            `json:"env_vars"`


### PR DESCRIPTION
This change adds a TargetPort field to the Server struct in the registry
package. This allows specifying the target port in the registry, which is
particularly useful for SSE transport mode where we need to know what port
the SSE server is going to be listening on.

This makes the registry more portable and flexible, especially for SSE servers
that need to expose specific ports.
