### PR TITLE
minor refactor and adds missing tests

### DIFF
--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -3,12 +3,240 @@
 package client
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/StacklokLabs/toolhive/pkg/config"
+	"github.com/StacklokLabs/toolhive/pkg/logger"
 	"github.com/StacklokLabs/toolhive/pkg/transport/ssecommon"
 )
 
-// TODO: Chris, add betters tests for config layer.
+// createMockClientConfigs creates a set of mock client configurations for testing
+func createMockClientConfigs() []mcpClientConfig {
+	return []mcpClientConfig{
+		{
+			ClientType:           VSCode,
+			Description:          "Visual Studio Code (Mock)",
+			RelPath:              []string{"mock_vscode", "settings.json"},
+			MCPServersPathPrefix: "/mcp/servers",
+			Extension:            JSON,
+		},
+		{
+			ClientType:           Cursor,
+			Description:          "Cursor editor (Mock)",
+			RelPath:              []string{"mock_cursor", "mcp.json"},
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		},
+		{
+			ClientType:           RooCode,
+			Description:          "VS Code Roo Code extension (Mock)",
+			RelPath:              []string{"mock_roo", "mcp_settings.json"},
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		},
+	}
+}
+
+// MockConfig creates a temporary config file with the provided configuration.
+// It returns a cleanup function that should be deferred.
+func MockConfig(t *testing.T, cfg *config.Config) func() {
+	t.Helper()
+
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+
+	// Save original XDG_CONFIG_HOME
+	originalXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	// Create the config directory structure
+	configDir := filepath.Join(tempDir, "toolhive")
+	err := os.MkdirAll(configDir, 0755)
+	require.NoError(t, err)
+
+	// Write the config file if one is provided
+	if cfg != nil {
+		err = cfg.WriteConfig()
+		require.NoError(t, err)
+	}
+
+	return func() {
+		t.Setenv("XDG_CONFIG_HOME", originalXDGConfigHome)
+	}
+}
+
+func TestFindClientConfigs(t *testing.T) {
+	logger.Initialize()
+
+	// Setup a temporary home directory for testing
+	originalHome := os.Getenv("HOME")
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	defer func() {
+		t.Setenv("HOME", originalHome)
+	}()
+
+	// Save original supported clients and restore after test
+	originalClients := supportedClientIntegrations
+	defer func() {
+		supportedClientIntegrations = originalClients
+	}()
+
+	// Set up mock client configurations
+	supportedClientIntegrations = createMockClientConfigs()
+
+	// Create test config files for different clients
+	createTestConfigFiles(t, tempHome)
+
+	t.Run("AutoDiscoveryEnabled", func(t *testing.T) {
+		// Set up config with auto-discovery enabled
+		testConfig := &config.Config{
+			Secrets: config.Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: config.Clients{
+				AutoDiscovery:     true,
+				RegisteredClients: []string{},
+			},
+		}
+
+		cleanup := MockConfig(t, testConfig)
+		defer cleanup()
+
+		// Find client configs
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+
+		// We should find configs for all supported clients that were created
+		assert.NotEmpty(t, configs)
+
+		// Verify that we found the expected client types
+		foundClients := make(map[MCPClient]bool)
+		for _, cf := range configs {
+			foundClients[cf.ClientType] = true
+		}
+
+		// Check that we found at least some of the expected clients
+		// Note: This depends on which config files were successfully created
+		assert.True(t, len(foundClients) > 0, "Should find at least one client config")
+	})
+
+	t.Run("AutoDiscoveryDisabledWithRegisteredClients", func(t *testing.T) {
+		// Set up config with auto-discovery disabled but with registered clients
+		testConfig := &config.Config{
+			Secrets: config.Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: config.Clients{
+				AutoDiscovery:     false,
+				RegisteredClients: []string{"vscode", "cursor"},
+			},
+		}
+
+		cleanup := MockConfig(t, testConfig)
+		defer cleanup()
+
+		// Find client configs
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+
+		// We should only find configs for the registered clients
+		foundClients := make(map[MCPClient]bool)
+		for _, cf := range configs {
+			foundClients[cf.ClientType] = true
+		}
+
+		// Check that we only found the registered clients
+		for _, clientName := range testConfig.Clients.RegisteredClients {
+			if foundClients[MCPClient(clientName)] {
+				// At least one registered client was found
+				return
+			}
+		}
+
+		// If we get here, it means none of the registered clients were found
+		// This is acceptable if the test environment doesn't have those clients configured
+		t.Log("None of the registered clients were found, but this may be expected in the test environment")
+	})
+
+	t.Run("AutoDiscoveryDisabledWithNoRegisteredClients", func(t *testing.T) {
+		// Set up config with auto-discovery disabled and no registered clients
+		testConfig := &config.Config{
+			Secrets: config.Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: config.Clients{
+				AutoDiscovery:     false,
+				RegisteredClients: []string{},
+			},
+		}
+
+		cleanup := MockConfig(t, testConfig)
+		defer cleanup()
+
+		// Find client configs
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+
+		// We should not find any configs
+		assert.Empty(t, configs)
+	})
+
+	t.Run("InvalidConfigFileFormat", func(t *testing.T) {
+		// Create an invalid JSON file
+		invalidPath := filepath.Join(tempHome, ".cursor", "invalid.json")
+		err := os.MkdirAll(filepath.Dir(invalidPath), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(invalidPath, []byte("{invalid json}"), 0644)
+		require.NoError(t, err)
+
+		// Create a custom client config that points to the invalid file
+		invalidClient := mcpClientConfig{
+			ClientType:           "invalid",
+			Description:          "Invalid client",
+			RelPath:              []string{".cursor", "invalid.json"},
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		}
+
+		// Save the original supported clients
+		originalClients := supportedClientIntegrations
+		defer func() {
+			supportedClientIntegrations = originalClients
+		}()
+
+		// Add our invalid client to the supported clients
+		supportedClientIntegrations = append(supportedClientIntegrations, invalidClient)
+
+		// Set up config with auto-discovery enabled
+		testConfig := &config.Config{
+			Secrets: config.Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: config.Clients{
+				AutoDiscovery:     true,
+				RegisteredClients: []string{},
+			},
+		}
+
+		cleanup := MockConfig(t, testConfig)
+		defer cleanup()
+
+		// Find client configs - this should fail due to the invalid JSON
+		_, err = FindClientConfigs()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to validate config file format")
+		// we check if cursor is in the error message because thats the
+		// config file that we inserted the bad json into
+		assert.Contains(t, err.Error(), "cursor")
+	})
+}
 
 func TestGenerateMCPServerURL(t *testing.T) {
 	t.Parallel()
@@ -43,5 +271,132 @@ func TestGenerateMCPServerURL(t *testing.T) {
 				t.Errorf("GenerateMCPServerURL() = %v, want %v", url, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSuccessfulClientConfigOperations(t *testing.T) {
+	logger.Initialize()
+
+	// Setup a temporary home directory for testing
+	originalHome := os.Getenv("HOME")
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	defer func() {
+		t.Setenv("HOME", originalHome)
+	}()
+
+	// Save original supported clients and restore after test
+	originalClients := supportedClientIntegrations
+	defer func() {
+		supportedClientIntegrations = originalClients
+	}()
+
+	// Set up mock client configurations
+	supportedClientIntegrations = createMockClientConfigs()
+
+	// Create test config files
+	createTestConfigFiles(t, tempHome)
+
+	t.Run("FindAllConfiguredClients", func(t *testing.T) {
+		// Set up config with auto-discovery enabled
+		testConfig := &config.Config{
+			Secrets: config.Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: config.Clients{
+				AutoDiscovery:     true,
+				RegisteredClients: []string{},
+			},
+		}
+
+		cleanup := MockConfig(t, testConfig)
+		defer cleanup()
+
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+		assert.Len(t, configs, len(supportedClientIntegrations), "Should find all mock client configs")
+
+		// Verify each client type is found
+		foundTypes := make(map[MCPClient]bool)
+		for _, cf := range configs {
+			foundTypes[cf.ClientType] = true
+		}
+
+		for _, expectedClient := range supportedClientIntegrations {
+			assert.True(t, foundTypes[expectedClient.ClientType],
+				"Should find config for client type %s", expectedClient.ClientType)
+		}
+	})
+
+	t.Run("VerifyConfigFileContents", func(t *testing.T) {
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+		require.NotEmpty(t, configs)
+
+		for _, cf := range configs {
+			// Read and parse the config file
+			content, err := os.ReadFile(cf.Path)
+			require.NoError(t, err, "Should be able to read config file for %s", cf.ClientType)
+
+			// Verify JSON structure based on client type
+			switch cf.ClientType {
+			case VSCode, VSCodeInsider:
+				assert.Contains(t, string(content), `"mcp":`,
+					"VSCode config should contain mcp key")
+				assert.Contains(t, string(content), `"servers":`,
+					"VSCode config should contain servers key")
+			case Cursor:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"Cursor config should contain mcpServers key")
+			case RooCode:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"RooCode config should contain mcpServers key")
+			}
+		}
+	})
+
+	t.Run("AddAndVerifyMCPServer", func(t *testing.T) {
+		configs, err := FindClientConfigs()
+		require.NoError(t, err)
+		require.NotEmpty(t, configs)
+
+		testServer := "test-server"
+		testURL := "http://localhost:9999/sse#test-server"
+
+		for _, cf := range configs {
+			err := Upsert(cf, testServer, testURL)
+			require.NoError(t, err, "Should be able to add MCP server to %s config", cf.ClientType)
+
+			// Read the file and verify the server was added
+			content, err := os.ReadFile(cf.Path)
+			require.NoError(t, err)
+
+			// Check based on client type
+			switch cf.ClientType {
+			case VSCode, VSCodeInsider:
+				assert.Contains(t, string(content), testURL,
+					"VSCode config should contain the server URL")
+			case Cursor, RooCode:
+				assert.Contains(t, string(content), testURL,
+					"Config should contain the server URL")
+			}
+		}
+	})
+}
+
+// Helper function to create test config files for different clients
+func createTestConfigFiles(t *testing.T, homeDir string) {
+	t.Helper()
+	// Create test config files for each mock client configuration
+	for _, cfg := range supportedClientIntegrations {
+		// Build the full path for the config file
+		configDir := filepath.Join(homeDir, filepath.Join(cfg.RelPath[:len(cfg.RelPath)-1]...))
+		err := os.MkdirAll(configDir, 0755)
+		if err == nil {
+			configPath := filepath.Join(configDir, cfg.RelPath[len(cfg.RelPath)-1])
+			validJSON := `{"mcpServers": {}, "mcp": {"servers": {}}}`
+			err = os.WriteFile(configPath, []byte(validJSON), 0644)
+			require.NoError(t, err)
+		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,14 @@ type Clients struct {
 	RegisteredClients []string `yaml:"registered_clients"`
 }
 
+// defaultPathGenerator generates the default config path using xdg
+var defaultPathGenerator = func() (string, error) {
+	return xdg.ConfigFile("toolhive/config.yaml")
+}
+
+// getConfigPath is the current path generator, can be replaced in tests
+var getConfigPath = defaultPathGenerator
+
 // LoadOrCreateConfig fetches the application configuration.
 // If it does not already exist - it will create a new config file with default values.
 func LoadOrCreateConfig() (*Config, error) {
@@ -135,9 +143,4 @@ func (c *Config) WriteConfig() error {
 		return fmt.Errorf("error writing config file: %w", err)
 	}
 	return nil
-}
-
-// Consider making the config path configurable.
-func getConfigPath() (string, error) {
-	return xdg.ConfigFile("toolhive/config.yaml")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/StacklokLabs/toolhive/pkg/logger"
+)
+
+// MockConfigPath replaces the getConfigPath function with a mock that returns a specified path
+func MockConfigPath(configPath string) func() {
+	original := getConfigPath
+
+	// Replace the function with our mock
+	getConfigPath = func() (string, error) {
+		return configPath, nil
+	}
+
+	// Return a cleanup function to restore the original
+	return func() {
+		getConfigPath = original
+	}
+}
+
+// SetupTestConfig creates a temporary config file and mocks the config path
+func SetupTestConfig(t *testing.T, configContent *Config) (string, func()) {
+	t.Helper()
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create config directory
+	configDir := filepath.Join(tempDir, "toolhive")
+	err := os.MkdirAll(configDir, 0755)
+	require.NoError(t, err)
+
+	// Set up the config file path
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	// If config content is provided, write it to the file
+	if configContent != nil {
+		configBytes, err := yaml.Marshal(configContent)
+		require.NoError(t, err)
+
+		err = os.WriteFile(configPath, configBytes, 0600)
+		require.NoError(t, err)
+	}
+
+	// Mock the config path function
+	cleanup := MockConfigPath(configPath)
+
+	return tempDir, cleanup
+}
+
+func TestLoadOrCreateConfig(t *testing.T) {
+	logger.Initialize()
+
+	t.Run("TestLoadOrCreateConfigWithMockConfig", func(t *testing.T) {
+		tempDir, cleanup := SetupTestConfig(t, &Config{
+			Secrets: Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: Clients{
+				AutoDiscovery:     true,
+				RegisteredClients: []string{"vscode", "cursor"},
+			},
+		})
+		defer cleanup()
+
+		// Load the config
+		config, err := LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Verify the loaded config matches our mock
+		assert.Equal(t, "encrypted", config.Secrets.ProviderType)
+		assert.True(t, config.Clients.AutoDiscovery)
+		assert.Equal(t, []string{"vscode", "cursor"}, config.Clients.RegisteredClients)
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("TestLoadOrCreateConfigWithNewConfig", func(t *testing.T) {
+		// Create a temporary directory for the test
+		tempDir, cleanup := SetupTestConfig(t, nil)
+		defer cleanup()
+
+		// Load the config - this should create a new one since none exists
+		config, err := LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Verify the default values
+		assert.Equal(t, "encrypted", config.Secrets.ProviderType)
+		assert.False(t, config.Clients.AutoDiscovery) // Default is false when no input is provided
+		assert.Empty(t, config.Clients.RegisteredClients)
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}
+
+func TestWriteConfig(t *testing.T) {
+	logger.Initialize()
+
+	t.Run("TestWriteConfig", func(t *testing.T) {
+		// Create a temporary directory for the test
+		tempDir := t.TempDir()
+
+		// Save original XDG_CONFIG_HOME and restore after test
+		originalXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		t.Setenv("XDG_CONFIG_HOME", tempDir)
+		defer func() {
+			t.Setenv("XDG_CONFIG_HOME", originalXDGConfigHome)
+		}()
+
+		// Create a config instance
+		config := &Config{
+			Secrets: Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: Clients{
+				AutoDiscovery:     true,
+				RegisteredClients: []string{"vscode", "cursor", "roo-code"},
+			},
+		}
+
+		// Write the config
+		err := config.WriteConfig()
+		require.NoError(t, err)
+
+		// Verify the file was created
+		configPath, err := getConfigPath()
+		require.NoError(t, err)
+
+		_, err = os.Stat(configPath)
+		require.NoError(t, err)
+
+		// Read the file and verify its contents
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+
+		// Load the config from the file
+		loadedConfig := &Config{}
+		err = yaml.Unmarshal(data, loadedConfig)
+		require.NoError(t, err)
+
+		// Verify the loaded config matches what we wrote
+		assert.Equal(t, config.Secrets.ProviderType, loadedConfig.Secrets.ProviderType)
+		assert.Equal(t, config.Clients.AutoDiscovery, loadedConfig.Clients.AutoDiscovery)
+		assert.Equal(t, config.Clients.RegisteredClients, loadedConfig.Clients.RegisteredClients)
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}


### PR DESCRIPTION
Here we separate the editor from the config file metadata operations. this allows us to keep operaions decoupled and to avoid bleeding logic into the wrong layers. we also add missing tests for the FindClientConfigs method that greatly increases our test coverage as well as adding tests for the ToolHive config file package where there were none before.