### PR TITLE
feat: Use server Args from registry

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -242,6 +242,12 @@ func applyRegistrySettings(
 		runTargetPort = server.TargetPort
 	}
 
+	// Prepend registry args to command-line args if available
+	if len(server.Args) > 0 {
+		logDebug(debugMode, "Prepending registry args: %v", server.Args)
+		config.CmdArgs = append(server.Args, config.CmdArgs...)
+	}
+
 	// Process environment variables from registry
 	// This will be merged with command-line env vars in configureRunConfig
 	envVarStrings := processEnvironmentVariables(server.EnvVars, runEnv, config.Secrets, debugMode)

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -21,15 +21,17 @@ type Server struct {
 	Description string `json:"description"`
 	Transport   string `json:"transport"`
 	// TargetPort is the port for the container to expose (only applicable to SSE transport)
-	TargetPort    int                  `json:"target_port,omitempty"`
-	Permissions   *permissions.Profile `json:"permissions"`
-	Tools         []string             `json:"tools"`
-	EnvVars       []*EnvVar            `json:"env_vars"`
-	Args          []string             `json:"args"`
-	Metadata      *Metadata            `json:"metadata"`
-	RepositoryURL string               `json:"repository_url,omitempty"`
-	Tags          []string             `json:"tags,omitempty"`
-	DockerTags    []string             `json:"docker_tags,omitempty"`
+	TargetPort  int                  `json:"target_port,omitempty"`
+	Permissions *permissions.Profile `json:"permissions"`
+	Tools       []string             `json:"tools"`
+	EnvVars     []*EnvVar            `json:"env_vars"`
+	// Args are the default command-line arguments to pass to the MCP server container.
+	// These arguments will be prepended to any command-line arguments provided by the user.
+	Args          []string  `json:"args"`
+	Metadata      *Metadata `json:"metadata"`
+	RepositoryURL string    `json:"repository_url,omitempty"`
+	Tags          []string  `json:"tags,omitempty"`
+	DockerTags    []string  `json:"docker_tags,omitempty"`
 }
 
 // EnvVar represents an environment variable for an MCP server


### PR DESCRIPTION
This change implements the functionality to use the Args field from the Server struct in the MCP registry. When an MCP server is run, any arguments defined in the registry entry will be prepended to the command-line arguments provided by the user.
