### PR TITLE
Add NetBird MCP server to registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1648,13 +1648,11 @@
        "write": [],
        "network": {
          "outbound": {
-           "insecure_allow_all": false,
+           "insecure_allow_all": true,
            "allow_transport": [
              "tcp"
            ],
-           "allow_host": [
-             "api.netbird.io"
-           ],
+           "allow_host": [],
            "allow_port": [
              443
            ]
@@ -1682,7 +1680,7 @@
          "required": false
        }
      ],
-     "args": ["--transport", "sse"],
+     "args": ["--transport", "sse", "--sse-address", ":8001"],
      "metadata": {
        "stars": 27,
        "pulls": 0,

--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1637,6 +1637,68 @@
        "ast",
        "code-analysis"
      ]
+   },
+   "netbird": {
+     "image": "aantti/mcp-netbird:latest",
+     "description": "A Model Context Protocol server for NetBird, enabling management of your NetBird network.",
+     "transport": "sse",
+     "target_port": 8001,
+     "permissions": {
+       "read": [],
+       "write": [],
+       "network": {
+         "outbound": {
+           "insecure_allow_all": false,
+           "allow_transport": [
+             "tcp"
+           ],
+           "allow_host": [
+             "api.netbird.io"
+           ],
+           "allow_port": [
+             443
+           ]
+         }
+       }
+     },
+     "tools": [
+       "list_netbird_peers",
+       "list_netbird_port_allocations",
+       "list_netbird_groups",
+       "list_netbird_policies",
+       "list_netbird_posture_checks",
+       "list_netbird_networks",
+       "list_netbird_nameservers"
+     ],
+     "env_vars": [
+       {
+         "name": "NETBIRD_API_TOKEN",
+         "description": "NetBird API token for authentication",
+         "required": true
+       },
+       {
+         "name": "NETBIRD_HOST",
+         "description": "NetBird API host (default is api.netbird.io)",
+         "required": false
+       }
+     ],
+     "args": ["--transport", "sse"],
+     "metadata": {
+       "stars": 27,
+       "pulls": 0,
+       "last_updated": "2025-04-15T17:21:00Z"
+     },
+     "repository_url": "https://github.com/aantti/mcp-netbird",
+     "tags": [
+       "netbird",
+       "vpn",
+       "networking",
+       "peer",
+       "route",
+       "dns",
+       "setup-key",
+       "management"
+     ]
    }
  }
 }


### PR DESCRIPTION
This commit adds the NetBird MCP server to the registry.json file. NetBird is a
Model Context Protocol (MCP) server that provides access to NetBird network
management capabilities.

The server is configured with:
- SSE transport mode on port 8001
- Required NETBIRD_API_TOKEN environment variable
- Optional NETBIRD_HOST environment variable
- Seven tools for managing NetBird networks, peers, groups, and policies

GitHub repository: https://github.com/aantti/mcp-netbird
