### PR TITLE
fix: serverName was not being serialised

### DIFF
--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -83,7 +83,7 @@ func (jcu *JSONConfigUpdater) Upsert(serverName string, data MCPServer) error {
 		logger.Log.Error("Failed to write file: %v", err)
 	}
 
-	logger.Log.Info("Successfully updated the client config file for MCPServer %s", serverName)
+	logger.Log.Info(fmt.Sprintf("Successfully updated the client config file for MCPServer %s", serverName))
 
 	return nil
 }


### PR DESCRIPTION
adds a fmt.sprintf to ensure the serverName is being serialised when being logged