### PR TITLE
[PoC] SECCOMP profiles

### DIFF
--- a/pkg/container/docker/seccomp.go
+++ b/pkg/container/docker/seccomp.go
@@ -1,0 +1,85 @@
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/StacklokLabs/toolhive/pkg/permissions"
+)
+
+// Docker JSON format (should be compat with podman too)
+type seccompProfileTemplate struct {
+	DefaultAction string                       `json:"defaultAction"`
+	Architectures []string                     `json:"architectures,omitempty"`
+	Syscalls      []seccompSyscallRuleTemplate `json:"syscalls"`
+}
+
+type seccompSyscallRuleTemplate struct {
+	Names  []string `json:"names"`
+	Action string   `json:"action"`
+}
+
+func generateSeccompProfile(profile *permissions.Profile) (string, error) {
+	if profile.Seccomp == nil {
+		return "", nil
+	}
+
+	// Check if seccomp is explicitly disabled for this profile
+	// This basically returns empty profile, meaning, but does not mean no profiles
+	// at all, as Docker and Podman have pretty good profiles out of the box
+	// https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile
+	if !profile.Seccomp.Enabled {
+		logger.Log.Info("Seccomp profile generation skipped as profile.Seccomp.Enabled is false.")
+		return "", nil
+	}
+
+	// What sort of action to take on a profile match
+	defaultAction := "SCMP_ACT_ERRNO"
+	if profile.Seccomp.DefaultAction != "" {
+		switch profile.Seccomp.DefaultAction {
+		case "allow":
+			defaultAction = "SCMP_ACT_ALLOW"
+		case "errno":
+			defaultAction = "SCMP_ACT_ERRNO"
+		case "kill":
+			defaultAction = "SCMP_ACT_KILL"
+		case "trap":
+			defaultAction = "SCMP_ACT_TRAP"
+		case "trace":
+			defaultAction = "SCMP_ACT_TRACE"
+		default:
+			logger.Log.Warn(fmt.Sprintf("Warning: Unknown seccomp default action: %s, using SCMP_ACT_ERRNO", profile.Seccomp.DefaultAction))
+		}
+	}
+
+	// seccomp profile template
+	seccompProfile := seccompProfileTemplate{
+		DefaultAction: defaultAction,
+		Architectures: profile.Seccomp.Architectures,
+		Syscalls:      []seccompSyscallRuleTemplate{},
+	}
+
+	// Add denied syscalls with ERRNO action
+	if len(profile.Seccomp.DeniedSyscalls) > 0 {
+		seccompProfile.Syscalls = append(seccompProfile.Syscalls, seccompSyscallRuleTemplate{
+			Names:  profile.Seccomp.DeniedSyscalls,
+			Action: "SCMP_ACT_ERRNO",
+		})
+	}
+
+	// Add allowed syscalls with ALLOW action
+	if len(profile.Seccomp.AllowedSyscalls) > 0 {
+		seccompProfile.Syscalls = append(seccompProfile.Syscalls, seccompSyscallRuleTemplate{
+			Names:  profile.Seccomp.AllowedSyscalls,
+			Action: "SCMP_ACT_ALLOW",
+		})
+	}
+
+	seccompJSON, err := json.Marshal(seccompProfile)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal seccomp profile: %w", err)
+	}
+
+	return string(seccompJSON), nil
+}

--- a/pkg/permissions/profile.go
+++ b/pkg/permissions/profile.go
@@ -34,6 +34,32 @@ type Profile struct {
 
 	// Network defines network permissions
 	Network *NetworkPermissions `json:"network,omitempty"`
+
+	// Seccomp defines seccomp profile configuration for system call filtering
+	Seccomp *SeccompProfile `json:"seccomp,omitempty"`
+}
+
+// SeccompProfile defines seccomp syscall filtering configuration
+type SeccompProfile struct {
+	// Enabled controls whether this seccomp profile is applied at all. Defaults to true.
+	Enabled bool `json:"enabled"`
+
+	// DeniedSyscalls is a list of syscalls to deny (will return EPERM)
+	DeniedSyscalls []string `json:"denied_syscalls,omitempty"`
+
+	// AllowedSyscalls is a list of syscalls to explicitly allow
+	AllowedSyscalls []string `json:"allowed_syscalls,omitempty"`
+
+	// DefaultAction defines the action for syscalls not in DeniedSyscalls or AllowedSyscalls
+	// Valid values: "allow", "errno" (default), "kill", "trap", "trace"
+	DefaultAction string `json:"default_action,omitempty"`
+
+	// Architectures is a list of architectures to apply the seccomp profile to
+	// If not specified, the profile will apply to all architectures
+	// This should support all Docker architectures
+	// Valid values: "x86_64", "386", "arm", "arm64", "mips", "mips64", "ppc64le", "s390x"
+	// Note from Luke: I only checked x86_64 and arm64 so far
+	Architectures []string `json:"architectures,omitempty"`
 }
 
 // NetworkPermissions defines network permissions for a container
@@ -70,6 +96,13 @@ func NewProfile() *Profile {
 				AllowPort:        []int{},
 			},
 		},
+		Seccomp: &SeccompProfile{
+			Enabled:         true,
+			DeniedSyscalls:  []string{"ptrace", "reboot", "kexec_load"},
+			AllowedSyscalls: []string{"read", "write", "exit", "open", "close"},
+			DefaultAction:   "errno",
+			Architectures:   []string{"x86_64"},
+		},
 	}
 }
 
@@ -104,6 +137,13 @@ func BuiltinNoneProfile() *Profile {
 				AllowPort:        []int{},
 			},
 		},
+		Seccomp: &SeccompProfile{
+			Enabled:         true,
+			DeniedSyscalls:  []string{"ptrace", "reboot", "kexec_load"},
+			AllowedSyscalls: []string{"read", "write", "exit", "open", "close"},
+			DefaultAction:   "errno",
+			Architectures:   []string{"x86_64"},
+		},
 	}
 }
 
@@ -119,6 +159,13 @@ func BuiltinNetworkProfile() *Profile {
 				AllowHost:        []string{},
 				AllowPort:        []int{},
 			},
+		},
+		Seccomp: &SeccompProfile{
+			Enabled:         true,
+			DeniedSyscalls:  []string{"ptrace", "reboot", "kexec_load"},
+			AllowedSyscalls: []string{"read", "write", "exit", "open", "close"},
+			DefaultAction:   "errno",
+			Architectures:   []string{"x86_64"},
 		},
 	}
 }

--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1,6 +1,13 @@
 {
   "version": "1.0.0",
   "last_updated": "2025-03-25 16:58:54",
+  "seccomp_defaults": {
+    "enabled": false,
+    "denied_syscalls": ["ptrace", "reboot", "kexec_load"],
+    "allowed_syscalls": ["read", "write", "exit", "open", "close"],
+    "default_action": "errno",
+    "architectures": ["x86_64", "arm64"]
+  },
   "servers": {
     "fetch": {
       "image": "mcp/fetch:latest",
@@ -22,6 +29,11 @@
               443
             ]
           }
+        },
+        "seccomp": {
+          "enabled": false,
+          "denied_syscalls": ["ptrace", "reboot", "kexec_load"],
+          "allowed_syscalls": ["read", "write", "exit", "open", "close"]
         }
       },
       "tools": [
@@ -1660,13 +1672,7 @@
        }
      },
      "tools": [
-       "list_netbird_peers",
-       "list_netbird_port_allocations",
-       "list_netbird_groups",
-       "list_netbird_policies",
-       "list_netbird_posture_checks",
-       "list_netbird_networks",
-       "list_netbird_nameservers"
+       "retrieve_from_aws_kb"
      ],
      "env_vars": [
        {

--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1672,7 +1672,13 @@
        }
      },
      "tools": [
-       "retrieve_from_aws_kb"
+       "list_netbird_peers",
+       "list_netbird_port_allocations",
+       "list_netbird_groups",
+       "list_netbird_policies",
+       "list_netbird_posture_checks",
+       "list_netbird_networks",
+       "list_netbird_nameservers"
      ],
      "env_vars": [
        {


### PR DESCRIPTION
Don't feel you have to merge this, I got time to play a lot with toolhive last night and hacked up a way of injecting seccomp profiles during container runtime init

To be honest docker and podman have a good set of defaults, but I was thinking about how limited the scope of MCP servers tends to be (most are limited to specialised jobs) and so custom seccomp profiles seemed worth exploring

I really have not had much time to test this and so please don't feel a need to merge quickly if at all, I don't want to introduce a security risk from me hacking away with curiosity.

iirc correctly, the order is:

1. Server-specific overrides: Individual configuration in each server's `permissions.seccomp` section in registry.json

2. Global defaults: From `seccomp_defaults` section in registry.json

3. Fallback defaults: Hardcoded in `NewProfile()` function, used only if registry.json is missing and to make sure a footgun does not happen

You can see the rules applied using inspect

```bash
docker inspect --format '{{.HostConfig.SecurityOpt}}' ffdcb25d76cf
[seccomp={"defaultAction":"SCMP_ACT_ERRNO","syscalls":[{"names":["ptrace","reboot","kexec_load"],"action":"SCMP_ACT_ERRNO"},{"names":["read","write","exit","open","close"],"action":"SCMP_ACT_ALLOW"}]}]
```