### PR TITLE
Sort registry list by name instead of image

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -61,7 +61,7 @@ func registryListCmdFunc(_ *cobra.Command, _ []string) error {
 
 	// Sort servers by name
 	sort.Slice(servers, func(i, j int) bool {
-		return servers[i].Image < servers[j].Image
+		return servers[i].Name < servers[j].Name
 	})
 
 	// Output based on format


### PR DESCRIPTION
Sort the `registry list` outpub by name instead of image.

Closes #222