### PR TITLE
Change default permission profile to `network`

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -60,7 +60,7 @@ func init() {
 	runCmd.Flags().StringVar(
 		&runPermissionProfile,
 		"permission-profile",
-		permissions.ProfileNone,
+		permissions.ProfileNetwork,
 		"Permission profile to use (none, network, or path to JSON file)",
 	)
 	runCmd.Flags().StringArrayVarP(

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -26,7 +26,7 @@ thv run [flags] SERVER_OR_IMAGE [-- ARGS...]
       --oidc-client-id string       OIDC client ID
       --oidc-issuer string          OIDC issuer URL (e.g., https://accounts.google.com)
       --oidc-jwks-url string        URL to fetch the JWKS from
-      --permission-profile string   Permission profile to use (none, network, or path to JSON file) (default "none")
+      --permission-profile string   Permission profile to use (none, network, or path to JSON file) (default "network")
       --port int                    Port for the HTTP proxy to listen on (host port)
       --secret stringArray          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
       --target-host string          Host to forward traffic to (only applicable to SSE transport) (default "localhost")


### PR DESCRIPTION
This should make it easier to run API-accessing MCPs.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
