### PR TITLE
Switch uvx template from Alpine to Debian-slim

### DIFF
--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -21,7 +21,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				MCPArgs:    []string{"--arg1", "--arg2", "value"},
 			},
 			wantContains: []string{
-				"FROM python:3.12-alpine",
+				"FROM python:3.12-slim",
 				"RUN pip install --no-cache-dir uv",
 				"ENTRYPOINT [\"uvx\", \"example-package\", \"--arg1\", \"--arg2\", \"value\"]",
 			},

--- a/pkg/container/templates/uvx.tmpl
+++ b/pkg/container/templates/uvx.tmpl
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.12-slim
 
 # Install uv package manager
 RUN pip install --no-cache-dir uv
@@ -7,10 +7,12 @@ RUN pip install --no-cache-dir uv
 WORKDIR /app
 
 # Create a non-root user to run the application and set proper permissions
-RUN addgroup -S appgroup && \
-    adduser -S appuser -G appgroup && \
+RUN groupadd -r appgroup && \
+    useradd -r -g appgroup -m appuser && \
     mkdir -p /app && \
-    chown -R appuser:appgroup /app
+    chown -R appuser:appgroup /app && \
+    mkdir -p /home/appuser/.cache && \
+    chown -R appuser:appgroup /home/appuser
 
 # Set environment variables for better performance in containers
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
This change improves compatibility and resolves permission issues with the uv package manager.

Ended up making this change prompted by some packages (like playwright) not working in alpine.