### PR TITLE
Skip update check for completion command

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -43,3 +43,11 @@ func NewRootCmd() *cobra.Command {
 
 	return rootCmd
 }
+
+// IsCompletionCommand checks if the command being run is the completion command
+func IsCompletionCommand(args []string) bool {
+	if len(args) > 1 {
+		return args[1] == "completion"
+	}
+	return false
+}

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -13,7 +13,10 @@ func main() {
 	// Initialize the logger system
 	logger.Initialize()
 
-	checkForUpdates()
+	// Skip update check for completion command
+	if !app.IsCompletionCommand(os.Args) {
+		checkForUpdates()
+	}
 
 	if err := app.NewRootCmd().Execute(); err != nil {
 		logger.Log.Errorf("%v, %v", os.Stderr, err)


### PR DESCRIPTION
Skip the update check for the `completion` command.

Previously, if the update check returned any output, it was included in the stdout content for the shell completions file, leading to shell errors when loading it.

Resolves #221