### PR TITLE
Only run registry update once a day and update more

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -2,15 +2,15 @@ name: Update Registry
 
 on:
   schedule:
-    # Run every hour
-    - cron: '0 * * * *'
+    # Run once a day at midnight UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
     # Allow manual triggering
     inputs:
       count:
         description: 'Number of entries to update'
         required: false
-        default: 3
+        default: 150
         type: number
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "count=${{ github.event.inputs.count }}" >> $GITHUB_OUTPUT
           else
-            echo "count=3" >> $GITHUB_OUTPUT
+            echo "count=150" >> $GITHUB_OUTPUT
           fi
 
       - name: Update registry


### PR DESCRIPTION
This changes the timer of the registry update github workflow
to only trigger once a day. This ensures we don't have as many
PRs as we have now (one every hour). This also increases the
number of entries we update.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
