### PR TITLE
cmd/thv: Improve help message for run subcommand

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -18,13 +18,29 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run [flags] SERVER_OR_IMAGE [-- ARGS...]",
+	Use:   "run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]",
 	Short: "Run an MCP server",
-	Long: `Run an MCP server in a container with the specified server name or image and arguments.
-If a server name is provided, it will first try to find it in the registry.
-If found, it will use the registry defaults for transport, permissions, etc.
-If not found, it will treat the argument as a Docker image and run it directly.
-The container will be started with minimal permissions and the specified transport mode.`,
+	Long: `Run an MCP server with the specified name, image, or protocol scheme.
+
+ToolHive supports three ways to run an MCP server:
+
+1. From the registry:
+   $ thv run server-name [-- args...]
+   Looks up the server in the registry and uses its predefined settings
+   (transport, permissions, environment variables, etc.)
+
+2. From a container image:
+   $ thv run ghcr.io/example/mcp-server:latest [-- args...]
+   Runs the specified container image directly with the provided arguments
+
+3. Using a protocol scheme:
+   $ thv run uvx://package-name [-- args...]
+   $ thv run npx://package-name [-- args...]
+   Automatically generates a container that runs the specified package
+   using either uvx (Python with uv package manager) or npx (Node.js)
+
+The container will be started with the specified transport mode and
+permission profile. Additional configuration can be provided via flags.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runCmdFunc,
 	// Ignore unknown flags to allow passing flags to the MCP server

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -4,14 +4,30 @@ Run an MCP server
 
 ### Synopsis
 
-Run an MCP server in a container with the specified server name or image and arguments.
-If a server name is provided, it will first try to find it in the registry.
-If found, it will use the registry defaults for transport, permissions, etc.
-If not found, it will treat the argument as a Docker image and run it directly.
-The container will be started with minimal permissions and the specified transport mode.
+Run an MCP server with the specified name, image, or protocol scheme.
+
+ToolHive supports three ways to run an MCP server:
+
+1. From the registry:
+   $ thv run server-name [-- args...]
+   Looks up the server in the registry and uses its predefined settings
+   (transport, permissions, environment variables, etc.)
+
+2. From a container image:
+   $ thv run ghcr.io/example/mcp-server:latest [-- args...]
+   Runs the specified container image directly with the provided arguments
+
+3. Using a protocol scheme:
+   $ thv run uvx://package-name [-- args...]
+   $ thv run npx://package-name [-- args...]
+   Automatically generates a container that runs the specified package
+   using either uvx (Python with uv package manager) or npx (Node.js)
+
+The container will be started with the specified transport mode and
+permission profile. Additional configuration can be provided via flags.
 
 ```
-thv run [flags] SERVER_OR_IMAGE [-- ARGS...]
+thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
 ```
 
 ### Options


### PR DESCRIPTION
This commit improves the help message for the `run` subcommand to clearly
explain all three modes of operation:

1. Running an MCP server from the registry
2. Running an MCP server from a container image
3. Running an MCP server using a protocol scheme (uvx:// or npx://)

The help message now includes examples for each mode and accurately
describes what each protocol scheme does:
- uvx:// creates a Python container using the uv package manager
- npx:// creates a Node.js container using npx

This makes the help message more thorough, accurate, and user-friendly
while remaining concise and focused on the essential information.
