### PR TITLE
docs: Update README to reflect renaming of stdio profile to none

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ on ports `80` and `443`.
 
 Two built-in profiles are included for convenience:
 
-- `stdio`: Grants minimal permissions with no network access.
+- `none`: Grants minimal permissions with no network access.
 - `network`: Permits outbound network connections to any host on any port (not
   recommended for production use).
 


### PR DESCRIPTION
Update the README.md file to reflect the renaming of the stdio permission profile to 'none'.
This change aligns with PR #166 where the profile was renamed to better reflect its purpose
of providing full isolation with no permissions.