### PR TITLE
Fix workflow and linting issues

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -1,6 +1,7 @@
 name: Operator CI
 
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
     paths:

--- a/cmd/thv/app/constants.go
+++ b/cmd/thv/app/constants.go
@@ -1,0 +1,9 @@
+package app
+
+// Output format constants
+const (
+	// FormatJSON is the JSON output format
+	FormatJSON = "json"
+	// FormatText is the text output format
+	FormatText = "text"
+)

--- a/cmd/thv/app/search.go
+++ b/cmd/thv/app/search.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(searchCmd)
 
 	// Add flags for search command
-	searchCmd.Flags().StringVar(&searchFormat, "format", "text", "Output format (json or text)")
+	searchCmd.Flags().StringVar(&searchFormat, "format", FormatText, "Output format (json or text)")
 }
 
 func searchCmdFunc(_ *cobra.Command, args []string) error {
@@ -52,7 +52,7 @@ func searchCmdFunc(_ *cobra.Command, args []string) error {
 
 	// Output based on format
 	switch searchFormat {
-	case "json":
+	case FormatJSON:
 		return printJSONSearchResults(servers)
 	default:
 		fmt.Printf("Found %d servers matching query: %s\n", len(servers), query)


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. Adds the missing `workflow_call` trigger to the operator-ci.yml workflow file, which allows it to be called from other workflows like run-on-pr.yml and run-on-main.yml. This fixes the CI error: "workflow is not reusable as it is missing a `on.workflow_call` trigger".

2. Creates a new constants.go file with output format constants (FormatJSON and FormatText) and updates search.go to use these constants instead of string literals. This fixes the linting issue: "string `json` has 4 occurrences, make it a constant (goconst)".

## Changes

- Added `workflow_call` trigger to .github/workflows/operator-ci.yml
- Created cmd/thv/app/constants.go with format constants
- Updated cmd/thv/app/search.go to use the constants

## Testing

- Verified that the linter runs successfully with no issues
- CI workflow should now run without errors