### PR TITLE
Add go:// transport protocol for golang containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,10 +347,11 @@ simplicity. When invoked:
 
 ToolHive supports running MCP servers directly from package managers using protocol schemes. This allows you to run MCP servers without having to build and publish Docker images first.
 
-Currently, two protocol schemes are supported:
+Currently, three protocol schemes are supported:
 
 - **uvx://**: For Python-based MCP servers using the uv package manager
 - **npx://**: For Node.js-based MCP servers using npm
+- **go://**: For Go-based MCP servers using the Go toolchain
 
 For example, to run a Python-based MCP server:
 
@@ -362,6 +363,12 @@ Or to run a Node.js-based MCP server:
 
 ```bash
 thv run npx://pulumi/mcp-server@latest
+```
+
+Or to run a Go-based MCP server:
+
+```bash
+thv run go://github.com/example/go-mcp-server@latest
 ```
 
 When you use a protocol scheme, ToolHive will:

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -36,8 +36,10 @@ ToolHive supports three ways to run an MCP server:
 3. Using a protocol scheme:
    $ thv run uvx://package-name [-- args...]
    $ thv run npx://package-name [-- args...]
+   $ thv run go://package-name [-- args...]
    Automatically generates a container that runs the specified package
-   using either uvx (Python with uv package manager) or npx (Node.js)
+   using either uvx (Python with uv package manager), npx (Node.js),
+   or go (Golang)
 
 The container will be started with the specified transport mode and
 permission profile. Additional configuration can be provided via flags.`,

--- a/cmd/thv/app/run_protocol.go
+++ b/cmd/thv/app/run_protocol.go
@@ -17,6 +17,7 @@ import (
 const (
 	UVXScheme = "uvx://"
 	NPXScheme = "npx://"
+	GOScheme  = "go://"
 )
 
 // handleProtocolScheme checks if the serverOrImage string contains a protocol scheme (uvx:// or npx://)
@@ -24,7 +25,9 @@ const (
 // Returns the Docker image name to use and any error encountered.
 func handleProtocolScheme(ctx context.Context, runtime rt.Runtime, serverOrImage string, debugMode bool) (string, error) {
 	// Check if the serverOrImage starts with a protocol scheme
-	if !strings.HasPrefix(serverOrImage, UVXScheme) && !strings.HasPrefix(serverOrImage, NPXScheme) {
+	if !strings.HasPrefix(serverOrImage, UVXScheme) &&
+		!strings.HasPrefix(serverOrImage, NPXScheme) &&
+		!strings.HasPrefix(serverOrImage, GOScheme) {
 		// No protocol scheme, return the original serverOrImage
 		return serverOrImage, nil
 	}
@@ -39,6 +42,9 @@ func handleProtocolScheme(ctx context.Context, runtime rt.Runtime, serverOrImage
 	} else if strings.HasPrefix(serverOrImage, NPXScheme) {
 		transportType = templates.TransportTypeNPX
 		packageName = strings.TrimPrefix(serverOrImage, NPXScheme)
+	} else if strings.HasPrefix(serverOrImage, GOScheme) {
+		transportType = templates.TransportTypeGO
+		packageName = strings.TrimPrefix(serverOrImage, GOScheme)
 	} else {
 		return "", fmt.Errorf("unsupported protocol scheme: %s", serverOrImage)
 	}

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -20,8 +20,10 @@ ToolHive supports three ways to run an MCP server:
 3. Using a protocol scheme:
    $ thv run uvx://package-name [-- args...]
    $ thv run npx://package-name [-- args...]
+   $ thv run go://package-name [-- args...]
    Automatically generates a container that runs the specified package
-   using either uvx (Python with uv package manager) or npx (Node.js)
+   using either uvx (Python with uv package manager), npx (Node.js),
+   or go (Golang)
 
 The container will be started with the specified transport mode and
 permission profile. Additional configuration can be provided via flags.

--- a/pkg/container/templates/go.tmpl
+++ b/pkg/container/templates/go.tmpl
@@ -1,0 +1,25 @@
+FROM golang:1.24-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Create a non-root user to run the application and set proper permissions
+RUN addgroup -S appgroup && \
+    adduser -S appuser -G appgroup && \
+    mkdir -p /app && \
+    chown -R appuser:appgroup /app && \
+    mkdir -p /home/appuser/.cache && \
+    chown -R appuser:appgroup /home/appuser
+
+# Set environment variables for better performance in containers
+ENV CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    GO111MODULE=on
+
+# Switch to non-root user
+USER appuser
+
+# Run the MCP server using go
+# The entrypoint will be constructed dynamically based on the package and arguments
+ENTRYPOINT ["go", "run", "{{.MCPPackage}}"{{range .MCPArgs}}, "{{.}}"{{end}}]

--- a/pkg/container/templates/templates.go
+++ b/pkg/container/templates/templates.go
@@ -28,6 +28,8 @@ const (
 	TransportTypeUVX TransportType = "uvx"
 	// TransportTypeNPX represents the npx transport.
 	TransportTypeNPX TransportType = "npx"
+	// TransportTypeGO represents the go transport.
+	TransportTypeGO TransportType = "go"
 )
 
 // GetDockerfileTemplate returns the Dockerfile template for the specified transport type.
@@ -40,6 +42,8 @@ func GetDockerfileTemplate(transportType TransportType, data TemplateData) (stri
 		templateName = "uvx.tmpl"
 	case TransportTypeNPX:
 		templateName = "npx.tmpl"
+	case TransportTypeGO:
+		templateName = "go.tmpl"
 	default:
 		return "", fmt.Errorf("unsupported transport type: %s", transportType)
 	}
@@ -72,6 +76,8 @@ func ParseTransportType(s string) (TransportType, error) {
 		return TransportTypeUVX, nil
 	case "npx":
 		return TransportTypeNPX, nil
+	case "go":
+		return TransportTypeGO, nil
 	default:
 		return "", fmt.Errorf("unsupported transport type: %s", s)
 	}

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -41,6 +41,19 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:          "GO transport",
+			transportType: TransportTypeGO,
+			data: TemplateData{
+				MCPPackage: "example-package",
+				MCPArgs:    []string{"--arg1", "--arg2", "value"},
+			},
+			wantContains: []string{
+				"FROM golang:1.24-alpine",
+				"ENTRYPOINT [\"go\", \"run\", \"example-package\", \"--arg1\", \"--arg2\", \"value\"]",
+			},
+			wantErr: false,
+		},
+		{
 			name:          "Unsupported transport",
 			transportType: "unsupported",
 			data: TemplateData{
@@ -90,6 +103,12 @@ func TestParseTransportType(t *testing.T) {
 			name:    "NPX transport",
 			s:       "npx",
 			want:    TransportTypeNPX,
+			wantErr: false,
+		},
+		{
+			name:    "GO transport",
+			s:       "go",
+			want:    TransportTypeGO,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
This PR adds support for the go:// transport protocol, which allows running Go-based MCP servers using the Go toolchain.

## Changes

- Added a new template file `pkg/container/templates/go.tmpl` that uses the golang:1.24-alpine image
- Added a new transport type constant `TransportTypeGO` in the templates package
- Updated the template handling functions to support the new go transport type
- Added a new protocol scheme constant `GOScheme` in the run_protocol.go file
- Updated the protocol scheme handling to support the new go:// protocol
- Updated the help text in run.go to include the new go:// protocol in the documentation
- Updated the README.md to include information about the new go:// protocol
- Added tests for the new go transport type

## Example Usage

```bash
thv run go://github.com/example/go-mcp-server@latest
```

This will automatically generate a container that runs the specified Go package using the Go toolchain.