### PR TITLE
Use toolhive service account for MCP server pods

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -38,6 +38,7 @@ kubectl apply -f deploy/operator/namespace.yaml
 
 ```bash
 kubectl apply -f deploy/operator/rbac.yaml
+kubectl apply -f deploy/operator/toolhive_rbac.yaml
 ```
 
 4. Deploy the operator:

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -323,6 +323,7 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "toolhive",
 					Containers: []corev1.Container{{
 						Image:        getToolhiveRunnerImage(),
 						Name:         "toolhive",
@@ -528,6 +529,11 @@ func deploymentNeedsUpdate(deployment *appsv1.Deployment, mcpServer *mcpv1alpha1
 		if !reflect.DeepEqual(container.Resources, resourceRequirementsForMCPServer(mcpServer)) {
 			return true
 		}
+	}
+
+	// Check if the service account name has changed
+	if deployment.Spec.Template.Spec.ServiceAccountName != "toolhive" {
+		return true
 	}
 
 	return false

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: toolhive-operator
       containers:
       - name: manager
-        image: ko://github.com/StacklokLabs/toolhive/cmd/thv-operator
+        image: ghcr.io/stackloklabs/toolhive/operator:latest
         args:
         - --leader-elect
         resources:

--- a/deploy/operator/toolhive_rbac.yaml
+++ b/deploy/operator/toolhive_rbac.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: toolhive
+  namespace: toolhive-system
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: toolhive
+  namespace: toolhive-system
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+rules:
+  # StatefulSet management
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "apply"]
+  
+  # Service management
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "apply"]
+  
+  # Pod management
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  
+  # Pod logs
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  
+  # Pod attach (for attaching to containers)
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: toolhive
+  namespace: toolhive-system
+  labels:
+    app: toolhive
+    app.kubernetes.io/name: toolhive
+subjects:
+- kind: ServiceAccount
+  name: toolhive
+roleRef:
+  kind: Role
+  name: toolhive
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR implements the principle of least privilege by:

1. Using the toolhive service account for MCP server pods instead of the default one
2. Adding a check to update existing deployments to use the correct service account
3. Updating the README to include applying the toolhive_rbac.yaml file
4. Updating the operator image reference to use the latest version

These changes ensure that the pods created by the operator have only the permissions they need to function properly, reducing the potential attack surface.