### PR TITLE
adds toolhive namespace for sample

### DIFF
--- a/deploy/operator/samples/mcpserver_fetch.yaml
+++ b/deploy/operator/samples/mcpserver_fetch.yaml
@@ -2,6 +2,7 @@ apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: fetch
+  namespace: toolhive-system
 spec:
   image: docker.io/mcp/fetch
   transport: stdio


### PR DESCRIPTION
Currently, for the operator, you need to install the MCPServer in the same namespace.