### PR TITLE
fix: attach and logs where not working for containers

### DIFF
--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -132,7 +132,7 @@ func (c *Client) AttachContainer(ctx context.Context, containerID string) (io.Wr
 	podName := pods.Items[0].Name
 
 	attachOpts := &corev1.PodAttachOptions{
-		Container: containerID,
+		Container: mcpContainerName,
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
@@ -223,7 +223,7 @@ func (c *Client) ContainerLogs(ctx context.Context, containerID string) (string,
 
 	// Get logs from the pod
 	logOptions := &corev1.PodLogOptions{
-		Container:  containerID, // Use the container name within the pod
+		Container:  mcpContainerName, // Use the container name within the pod
 		Follow:     false,
 		Previous:   false,
 		Timestamps: true,


### PR DESCRIPTION
When running the Kubernetes Operator, it was noticed that there were no connection logs or healthy MCP servers in my Client because the proxy pod was not correctly attaching to the MCP server. 

![image](https://github.com/user-attachments/assets/09c3ec54-2dc6-4e2e-8fbc-b380a6241100)

This is because we hardcoded the container name to ["mcp"](https://github.com/StacklokLabs/toolhive/blob/main/pkg/container/kubernetes/client.go#L1035) but we still try to attach and find the logs of the container by a dynamic name. This commit hardcodes the container name for the attaching and retrieving of logs like when it is created, this should then allow for the attaching by the proxy pod to work.