### PR TITLE
fix: explicit naming for Kuberentes Services for Proxy and MCP server

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -355,9 +355,13 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 func (r *MCPServerReconciler) serviceForMCPServer(m *mcpv1alpha1.MCPServer) *corev1.Service {
 	ls := labelsForMCPServer(m.Name)
 
+	// we want to generate a service name that is unique for the proxy service
+	// to avoid conflicts with the headless service
+	svcName := fmt.Sprintf("mcp-%s-proxy", m.Name)
+
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name,
+			Name:      svcName,
 			Namespace: m.Namespace,
 		},
 		Spec: corev1.ServiceSpec{

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -136,7 +136,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Check if the Service already exists, if not create a new one
 	service := &corev1.Service{}
 	err = r.Get(ctx, types.NamespacedName{Name: mcpServer.Name, Namespace: mcpServer.Namespace}, service)
-	if err != nil && errors.IsNotFound(err) && mcpServer.Spec.Transport != "sse" {
+	if err != nil && errors.IsNotFound(err) {
 		// Define a new service
 		svc := r.serviceForMCPServer(mcpServer)
 		if svc == nil {

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -136,7 +136,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Check if the Service already exists, if not create a new one
 	service := &corev1.Service{}
 	err = r.Get(ctx, types.NamespacedName{Name: mcpServer.Name, Namespace: mcpServer.Namespace}, service)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && errors.IsNotFound(err) && mcpServer.Spec.Transport != "sse" {
 		// Define a new service
 		svc := r.serviceForMCPServer(mcpServer)
 		if svc == nil {

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: manager
         image: ghcr.io/stackloklabs/toolhive/operator:latest
+        imagePullPolicy: Always
         args:
         - --leader-elect
         resources:

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -806,8 +806,10 @@ func (c *Client) createHeadlessService(
 		}
 	}
 
+	svcName := fmt.Sprintf("%s-headless", containerName)
+
 	// Create the service apply configuration
-	serviceApply := corev1apply.Service(containerName, namespace).
+	serviceApply := corev1apply.Service(svcName, namespace).
 		WithLabels(labels).
 		WithSpec(corev1apply.ServiceSpec().
 			WithSelector(map[string]string{

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -806,7 +806,9 @@ func (c *Client) createHeadlessService(
 		}
 	}
 
-	svcName := fmt.Sprintf("%s-headless", containerName)
+	// we want to generate a service name that is unique for the headless service
+	// to avoid conflicts with the proxy service
+	svcName := fmt.Sprintf("mcp-%s-headless", containerName)
 
 	// Create the service apply configuration
 	serviceApply := corev1apply.Service(svcName, namespace).

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -223,7 +223,7 @@ func (c *Client) ContainerLogs(ctx context.Context, containerID string) (string,
 
 	// Get logs from the pod
 	logOptions := &corev1.PodLogOptions{
-		Container:  mcpContainerName, // Use the container name within the pod
+		Container:  mcpContainerName,
 		Follow:     false,
 		Previous:   false,
 		Timestamps: true,

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -132,7 +132,7 @@ func (c *Client) AttachContainer(ctx context.Context, containerID string) (io.Wr
 	podName := pods.Items[0].Name
 
 	attachOpts := &corev1.PodAttachOptions{
-		Container: containerID,
+		Container: mcpContainerName,
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
@@ -223,7 +223,7 @@ func (c *Client) ContainerLogs(ctx context.Context, containerID string) (string,
 
 	// Get logs from the pod
 	logOptions := &corev1.PodLogOptions{
-		Container:  containerID, // Use the container name within the pod
+		Container:  mcpContainerName, // Use the container name within the pod
 		Follow:     false,
 		Previous:   false,
 		Timestamps: true,


### PR DESCRIPTION
It appears that the issue seems to be that we create a [SVC via the Operator](https://github.com/StacklokLabs/toolhive/blob/main/cmd/thv-operator/controllers/mcpserver_controller.go#L136-L157) and then in the toolhive code we create a [headless SVC](https://github.com/StacklokLabs/toolhive/blob/main/pkg/container/kubernetes/client.go#L326) if the transport type is sse.

This ends up with the scenario where the toolhive container is trying to create a service with `ClusterIP: None`, however because the SVC has already been created by the Operator, it errors because the ClusterIP field is immutable and cannot be changed. In this PR we add explicit names to both services created by ToolHive.
This includes:
- The Proxy Service created by the Operator
- The Headless Service created by the ToolHive Runtime for MCP servers with SSE transport enabled.