### PR TITLE
feat: Claude Code Client Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ToolHive has been tested with the following clients:
 | Cursor            | ✅        |                                        |
 | Roo Code          | ✅        |                                        |
 | PydanticAI        | ✅        |                                        |
+| Claude Code       | ✅        |                                        |
 | Continue          | ❌        | Continue doesn't yet support SSE       |
 | Claude Desktop    | ❌        | Claude Desktop doesn't yet support SSE |
 

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -55,6 +55,7 @@ var registerClientCmd = &cobra.Command{
 Valid clients are:
   - roo-code: Roo Code extension for VS Code
   - cursor: Cursor editor
+  - claude-code: Claude Code CLI
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders edition`,
 	Args: cobra.ExactArgs(1),
@@ -68,6 +69,7 @@ var removeClientCmd = &cobra.Command{
 Valid clients are:
   - roo-code: Roo Code extension for VS Code
   - cursor: Cursor editor
+  - claude-code: Claude Code CLI
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders edition`,
 	Args: cobra.ExactArgs(1),
@@ -149,10 +151,10 @@ func registerClientCmdFunc(_ *cobra.Command, args []string) error {
 
 	// Validate the client type
 	switch clientType {
-	case "roo-code", "cursor", "vscode-insider", "vscode":
+	case "roo-code", "cursor", "claude-code", "vscode-insider", "vscode":
 		// Valid client type
 	default:
-		return fmt.Errorf("invalid client type: %s (valid types: roo-code, cursor, vscode, vscode-insider)", clientType)
+		return fmt.Errorf("invalid client type: %s (valid types: roo-code, cursor, claude-code, vscode, vscode-insider)", clientType)
 	}
 
 	err := config.UpdateConfig(func(c *config.Config) {
@@ -186,10 +188,10 @@ func removeClientCmdFunc(_ *cobra.Command, args []string) error {
 
 	// Validate the client type
 	switch clientType {
-	case "roo-code", "cursor", "vscode-insider", "vscode":
+	case "roo-code", "cursor", "claude-code", "vscode-insider", "vscode":
 		// Valid client type
 	default:
-		return fmt.Errorf("invalid client type: %s (valid types: roo-code, cursor, vscode, vscode-insider)", clientType)
+		return fmt.Errorf("invalid client type: %s (valid types: roo-code, cursor, claude-code, vscode, vscode-insider)", clientType)
 	}
 
 	err := config.UpdateConfig(func(c *config.Config) {

--- a/docs/cli/thv_config_register-client.md
+++ b/docs/cli/thv_config_register-client.md
@@ -8,6 +8,7 @@ Register a client for MCP server configuration.
 Valid clients are:
   - roo-code: Roo Code extension for VS Code
   - cursor: Cursor editor
+  - claude-code: Claude Code CLI
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders edition
 

--- a/docs/cli/thv_config_remove-client.md
+++ b/docs/cli/thv_config_remove-client.md
@@ -8,6 +8,7 @@ Remove a client from MCP server configuration.
 Valid clients are:
   - roo-code: Roo Code extension for VS Code
   - cursor: Cursor editor
+  - claude-code: Claude Code CLI
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders edition
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -32,6 +32,8 @@ const (
 	VSCodeInsider MCPClient = "vscode-insider"
 	// VSCode represents the standard VS Code editor.
 	VSCode MCPClient = "vscode"
+	// ClaudeCode represents the Claude Code CLI.
+	ClaudeCode MCPClient = "claude-code"
 )
 
 // Extension is extension of the client config file.
@@ -99,6 +101,13 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".cursor", "mcp.json"},
 		Extension:            JSON,
 	},
+	{
+		ClientType:           ClaudeCode,
+		Description:          "Claude Code CLI",
+		MCPServersPathPrefix: "/mcpServers",
+		RelPath:              []string{".claude.json"},
+		Extension:            JSON,
+	},
 }
 
 // ConfigFile represents a client configuration file
@@ -151,12 +160,12 @@ func FindClientConfigs() ([]ConfigFile, error) {
 // Upsert updates/inserts an MCP server in a client configuration file
 // It is a wrapper around the ConfigUpdater.Upsert method. Because the
 // ConfigUpdater is different for each client type, we need to handle
-// the different types of McpServer objects. For example, VSCode allows
+// the different types of McpServer objects. For example, VSCode and ClaudeCode allows
 // for a `type` field, but Cursor and others do not. This allows us to
 // build up more complex MCP server configurations for different clients
 // without leaking them into the CMD layer.
 func Upsert(cf ConfigFile, name string, url string) error {
-	if cf.ClientType == VSCode || cf.ClientType == VSCodeInsider {
+	if cf.ClientType == VSCode || cf.ClientType == VSCodeInsider || cf.ClientType == ClaudeCode {
 		return cf.ConfigUpdater.Upsert(name, MCPServer{Url: url, Type: "sse"})
 	}
 

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -39,6 +39,13 @@ func createMockClientConfigs() []mcpClientConfig {
 			MCPServersPathPrefix: "/mcpServers",
 			Extension:            JSON,
 		},
+		{
+			ClientType:           ClaudeCode,
+			Description:          "Claude Code CLI (Mock)",
+			RelPath:              []string{"mock_claude", ".claude.json"},
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		},
 	}
 }
 
@@ -135,7 +142,7 @@ func TestFindClientConfigs(t *testing.T) {
 			},
 			Clients: config.Clients{
 				AutoDiscovery:     false,
-				RegisteredClients: []string{"vscode", "cursor"},
+				RegisteredClients: []string{"vscode", "cursor", "claude-code"},
 			},
 		}
 
@@ -343,7 +350,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			switch cf.ClientType {
 			case VSCode, VSCodeInsider:
 				assert.Contains(t, string(content), `"mcp":`,
-					"VSCode config should contain mcp key")
+					"Cconfig should contain mcp key")
 				assert.Contains(t, string(content), `"servers":`,
 					"VSCode config should contain servers key")
 			case Cursor:
@@ -352,6 +359,9 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case RooCode:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"RooCode config should contain mcpServers key")
+			case ClaudeCode:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"ClaudeCode config should contain mcpServers key")
 			}
 		}
 	})
@@ -377,7 +387,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case VSCode, VSCodeInsider:
 				assert.Contains(t, string(content), testURL,
 					"VSCode config should contain the server URL")
-			case Cursor, RooCode:
+			case Cursor, RooCode, ClaudeCode:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -130,7 +130,7 @@ func TestSave(t *testing.T) {
 			},
 			Clients: Clients{
 				AutoDiscovery:     true,
-				RegisteredClients: []string{"vscode", "cursor", "roo-code"},
+				RegisteredClients: []string{"vscode", "cursor", "roo-code", "claude-code"},
 			},
 		}
 


### PR DESCRIPTION
Claude Code now supports SSE MCP servers. This PR adds the ability to register `claude-code` as Client, and makes sure that the auto-discovery can discovery the [user scoped](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#understanding-mcp-server-scopes) `.claude.json` file.

Ref: https://github.com/StacklokLabs/toolhive/issues/318