### PR TITLE
Set up VCS for anything starting in dev

### DIFF
--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"time"
 )
 
@@ -40,7 +41,7 @@ func GetVersionInfo() VersionInfo {
 	commit := Commit
 	buildDate := BuildDate
 
-	if ver == "dev" {
+	if strings.HasPrefix(ver, "dev") {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			// Try to get version from build info
 			for _, setting := range info.Settings {


### PR DESCRIPTION
This ensures we have the VCS info even on `dev dev` cases, which is when
the TOOLHIVE_DEV environment variable is set up.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
