### PR TITLE
Respect transport from registry when running

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -294,7 +294,7 @@ func applyRegistrySettings(
 	// Use registry transport if not overridden
 	if !cmd.Flags().Changed("transport") {
 		logDebug(debugMode, "Using registry transport: %s", server.Transport)
-		// The actual transport setting will be handled by configureRunConfig
+		runTransport = server.Transport
 	} else {
 		logDebug(debugMode, "Using provided transport: %s (overriding registry default: %s)",
 			runTransport, server.Transport)


### PR DESCRIPTION
This actually leverages the transport specified by the registry. This
had probably not been an issue since there's not many SSE servers in our
registry.

Closes https://github.com/StacklokLabs/toolhive/issues/337

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
