### PR TITLE
refactor: add .ko.yaml for shared image config and streamline CI image labels

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -63,7 +63,8 @@ jobs:
           fi
           
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv \
-            --image-label=org.opencontainers.image.source=https://github.com/StacklokLabs/toolhive,org.opencontainers.image.title="toolhive",org.opencontainers.image.vendor=Stacklok
+            --image-label=org.opencontainers.image.title="toolhive"
+
 
       - name: Sign Image with Cosign
         # This step uses the identity token to provision an ephemeral certificate
@@ -146,7 +147,7 @@ jobs:
           fi
           
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv-operator \
-            --image-label=org.opencontainers.image.source=https://github.com/StacklokLabs/toolhive,org.opencontainers.image.title="toolhive-operator",org.opencontainers.image.vendor=Stacklok
+            --image-label=org.opencontainers.image.title="toolhive-operator"
 
       - name: Sign Image with Cosign
         # This step uses the identity token to provision an ephemeral certificate

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,6 @@
+defaultBaseImage: gcr.io/distroless/base-nonroot
+
+labels:
+  org.opencontainers.image.licenses: Apache-2.0
+  org.opencontainers.image.source: https://github.com/StacklokLabs/toolhive
+  org.opencontainers.image.vendor: Stacklok


### PR DESCRIPTION
This change introduces a .ko.yaml file to centralize shared image configuration,
including setting the base image to `gcr.io/distroless/base-nonroot` and
defining common OCI labels such as license, source, and vendor. The distroless
base-nonroot image is chosen specifically for compatibility with OpenShift, which
runs containers using an arbitrary user ID [1]. This image avoids setting a fixed USER
and supports execution as a non-root user without requiring filesystem writes
to restricted locations.

The GitHub Actions CI workflow is also updated to remove duplicated image label
declarations. Image-specific labels, such as `org.opencontainers.image.title`,
remain in the ko build commands to support different values for the CLI and
operator images. These changes improve maintainability and ensure the resulting
images are compatible with OpenShift's strict security constraints.

[1] https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/creating-images#use-uid_create-images

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
