### PR TITLE
Begin refactoring container lifecycle logic out of CLI

### DIFF
--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -93,7 +93,7 @@ func secretsProviderCmdFunc(_ *cobra.Command, args []string) error {
 	return SetSecretsProvider(secrets.ProviderType(provider))
 }
 
-func autoDiscoveryCmdFunc(_ *cobra.Command, args []string) error {
+func autoDiscoveryCmdFunc(cmd *cobra.Command, args []string) error {
 	value := args[0]
 
 	// Validate the boolean value
@@ -113,7 +113,7 @@ func autoDiscoveryCmdFunc(_ *cobra.Command, args []string) error {
 		// If auto-discovery is enabled, update all registered clients with currently running MCPs
 		if enabled && len(c.Clients.RegisteredClients) > 0 {
 			for _, clientName := range c.Clients.RegisteredClients {
-				if err := addRunningMCPsToClient(clientName); err != nil {
+				if err := addRunningMCPsToClient(cmd.Context(), clientName); err != nil {
 					fmt.Printf("Warning: Failed to add running MCPs to client %s: %v\n", clientName, err)
 				}
 			}
@@ -128,7 +128,7 @@ func autoDiscoveryCmdFunc(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func registerClientCmdFunc(_ *cobra.Command, args []string) error {
+func registerClientCmdFunc(cmd *cobra.Command, args []string) error {
 	clientType := args[0]
 
 	// Validate the client type
@@ -158,7 +158,7 @@ func registerClientCmdFunc(_ *cobra.Command, args []string) error {
 	fmt.Printf("Successfully registered client: %s\n", clientType)
 
 	// Add currently running MCPs to the newly registered client
-	if err := addRunningMCPsToClient(clientType); err != nil {
+	if err := addRunningMCPsToClient(cmd.Context(), clientType); err != nil {
 		fmt.Printf("Warning: Failed to add running MCPs to client: %v\n", err)
 	}
 
@@ -202,11 +202,7 @@ func removeClientCmdFunc(_ *cobra.Command, args []string) error {
 }
 
 // addRunningMCPsToClient adds currently running MCP servers to the specified client's configuration
-func addRunningMCPsToClient(clientName string) error {
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+func addRunningMCPsToClient(ctx context.Context, clientName string) error {
 	// Create container runtime
 	runtime, err := container.NewFactory().Create(ctx)
 	if err != nil {

--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -62,7 +62,7 @@ func listCmdFunc(cmd *cobra.Command, _ []string) error {
 	// Create container runtime
 	toolHiveContainers, err := manager.ListContainers(ctx, listAll)
 	if err != nil {
-		return fmt.Errorf("failed to create container runtime: %v", err)
+		return fmt.Errorf("failed to list containers: %v", err)
 	}
 
 	if len(toolHiveContainers) == 0 {

--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -37,13 +36,10 @@ func logsCommand() *cobra.Command {
 	return logsCommand
 }
 
-func logsCmdFunc(_ *cobra.Command, args []string) error {
+func logsCmdFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	// Get container name
 	containerName := args[0]
-
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// Create container runtime
 	runtime, err := container.NewFactory().Create(ctx)

--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -49,6 +48,7 @@ func init() {
 }
 
 func proxyCmdFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	// Get the server name
 	serverName := args[0]
 
@@ -58,10 +58,6 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logger.Log.Infof("Using host port: %d", port)
-
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// Create middlewares slice
 	var middlewares []types.Middleware

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -1,18 +1,11 @@
 package app
 
 import (
-	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/client"
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/runner"
+	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
 )
 
 var rmCmd = &cobra.Command{
@@ -32,117 +25,20 @@ func init() {
 }
 
 //nolint:gocyclo // This function is complex but manageable
-func rmCmdFunc(_ *cobra.Command, args []string) error {
+func rmCmdFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	// Get container name
 	containerName := args[0]
 
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create container runtime
-	runtime, err := container.NewFactory().Create(ctx)
+	// Create container manager.
+	manager, err := lifecycle.NewManager(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create container runtime: %v", err)
+		return fmt.Errorf("failed to create container manager: %v", err)
 	}
 
-	// List containers to find the one with the given name
-	containers, err := runtime.ListContainers(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list containers: %v", err)
-	}
-
-	// Find the container with the given name
-	var containerID string
-	var isRunning bool
-	var containerLabels map[string]string
-	for _, c := range containers {
-		// Check if the container is managed by ToolHive
-		if !labels.IsToolHiveContainer(c.Labels) {
-			continue
-		}
-
-		// Check if the container name matches
-		name := labels.GetContainerName(c.Labels)
-		if name == "" {
-			name = c.Name // Fallback to container name
-		}
-
-		// Check if the name matches (exact match or prefix match)
-		if name == containerName || strings.HasPrefix(c.ID, containerName) {
-			containerID = c.ID
-			isRunning = strings.Contains(strings.ToLower(c.State), "running")
-			containerLabels = c.Labels
-			break
-		}
-	}
-
-	if containerID == "" {
-		return fmt.Errorf("container %s not found", containerName)
-	}
-
-	// Check if the container is running and force is not specified
-	if isRunning && !rmForce {
-		return fmt.Errorf("container %s is running. Use -f to force remove", containerName)
-	}
-
-	// Remove the container
-	logger.Log.Infof("Removing container %s...", containerName)
-	if err := runtime.RemoveContainer(ctx, containerID); err != nil {
-		return fmt.Errorf("failed to remove container: %v", err)
-	}
-
-	// Get the base name from the container labels
-	baseName := labels.GetContainerBaseName(containerLabels)
-	if baseName != "" {
-		// Delete the saved state if it exists
-		if err := runner.DeleteSavedConfig(ctx, baseName); err != nil {
-			logger.Log.Warnf("Warning: Failed to delete saved state: %v", err)
-		} else {
-			logger.Log.Infof("Saved state for %s removed", baseName)
-		}
-	}
-
-	logger.Log.Infof("Container %s removed", containerName)
-
-	if shouldRemoveClientConfig() {
-		if err := removeClientConfigurations(containerName); err != nil {
-			logger.Log.Warnf("Warning: Failed to remove client configurations: %v", err)
-		} else {
-			logger.Log.Infof("Client configurations for %s removed", containerName)
-		}
-	}
-
-	return nil
-}
-
-func shouldRemoveClientConfig() bool {
-	c := config.GetConfig()
-	return len(c.Clients.RegisteredClients) > 0 || c.Clients.AutoDiscovery
-}
-
-// updateClientConfigurations updates client configuration files with the MCP server URL
-func removeClientConfigurations(containerName string) error {
-	// Find client configuration files
-	configs, err := client.FindClientConfigs()
-	if err != nil {
-		return fmt.Errorf("failed to find client configurations: %w", err)
-	}
-
-	if len(configs) == 0 {
-		logger.Log.Infof("No client configuration files found")
-		return nil
-	}
-
-	for _, c := range configs {
-		logger.Log.Infof("Removing MCP server from client configuration: %s", c.Path)
-
-		if err := c.ConfigUpdater.Remove(containerName); err != nil {
-			logger.Log.Warnf("Warning: Failed to remove MCP server from client configurationn %s: %v", c.Path, err)
-			continue
-		}
-
-		logger.Log.Infof("Successfully removed MCP server from client configuration: %s", c.Path)
+	// Delete container.
+	if err := manager.DeleteContainer(ctx, containerName, rmForce); err != nil {
+		return fmt.Errorf("failed to delete container: %v", err)
 	}
 
 	return nil

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -130,6 +130,7 @@ func init() {
 }
 
 func runCmdFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	// Get the server name or image
 	serverOrImage := args[0]
 
@@ -138,10 +139,6 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Print the processed command arguments for debugging
 	logger.Log.Infof("Processed cmdArgs: %v", cmdArgs)
-
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// Get debug mode flag
 	debugMode, _ := cmd.Flags().GetBool("debug")

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -1,17 +1,13 @@
 package app
 
 import (
-	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
+	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
 	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/process"
 )
 
 var stopCmd = &cobra.Command{
@@ -30,128 +26,25 @@ func init() {
 	stopCmd.Flags().IntVar(&stopTimeout, "timeout", 30, "Timeout in seconds before forcibly stopping the container")
 }
 
-// findContainerID finds the container ID by name or ID prefix
-func findContainerID(ctx context.Context, runtime rt.Runtime, containerName string) (string, error) {
-	// List containers to find the one with the given name
-	containers, err := runtime.ListContainers(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to list containers: %v", err)
-	}
-
-	// Find the container with the given name
-	for _, c := range containers {
-		// Check if the container is managed by ToolHive
-		if !labels.IsToolHiveContainer(c.Labels) {
-			continue
-		}
-
-		// Check if the container name matches
-		name := labels.GetContainerName(c.Labels)
-		if name == "" {
-			name = c.Name // Fallback to container name
-		}
-
-		// Check if the name matches (exact match or prefix match)
-		if name == containerName || strings.HasPrefix(c.ID, containerName) {
-			return c.ID, nil
-		}
-	}
-
-	return "", fmt.Errorf("container %s not found", containerName)
-}
-
-// getContainerBaseName gets the base container name from the container labels
-func getContainerBaseName(ctx context.Context, runtime rt.Runtime, containerID string) (string, error) {
-	containers, err := runtime.ListContainers(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to list containers: %v", err)
-	}
-
-	for _, c := range containers {
-		if c.ID == containerID {
-			return labels.GetContainerBaseName(c.Labels), nil
-		}
-	}
-
-	return "", fmt.Errorf("container %s not found", containerID)
-}
-
-// stopProxyProcess stops the proxy process associated with the container
-func stopProxyProcess(containerBaseName string) {
-	if containerBaseName == "" {
-		logger.Log.Warnf("Warning: Could not find base container name in labels")
-		return
-	}
-
-	// Try to read the PID file and kill the process
-	pid, err := process.ReadPIDFile(containerBaseName)
-	if err != nil {
-		logger.Log.Errorf("No PID file found for %s, proxy may not be running in detached mode", containerBaseName)
-		return
-	}
-
-	// PID file found, try to kill the process
-	logger.Log.Infof("Stopping proxy process (PID: %d)...", pid)
-	if err := process.KillProcess(pid); err != nil {
-		logger.Log.Warnf("Warning: Failed to kill proxy process: %v", err)
-	} else {
-		logger.Log.Infof("Proxy process stopped")
-	}
-
-	// Remove the PID file
-	if err := process.RemovePIDFile(containerBaseName); err != nil {
-		logger.Log.Warnf("Warning: Failed to remove PID file: %v", err)
-	}
-}
-
-// stopContainer stops the container
-func stopContainer(ctx context.Context, runtime rt.Runtime, containerID, containerName string) error {
-	logger.Log.Infof("Stopping container %s...", containerName)
-	if err := runtime.StopContainer(ctx, containerID); err != nil {
-		return fmt.Errorf("failed to stop container: %v", err)
-	}
-
-	logger.Log.Infof("Container %s stopped", containerName)
-	return nil
-}
-
-func stopCmdFunc(_ *cobra.Command, args []string) error {
+func stopCmdFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	// Get container name
 	containerName := args[0]
 
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create container runtime
-	runtime, err := container.NewFactory().Create(ctx)
+	manager, err := lifecycle.NewManager(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create container runtime: %v", err)
+		return fmt.Errorf("failed to create container manager: %v", err)
 	}
 
-	// Find the container ID
-	containerID, err := findContainerID(ctx, runtime, containerName)
+	err = manager.StopContainer(ctx, containerName)
 	if err != nil {
-		return err
+		// If the container is not found, treat as a non-fatal error.
+		if errors.Is(err, lifecycle.ErrContainerNotFound) {
+			logger.Log.Infof("Container %s is not running", containerName)
+		} else {
+			return fmt.Errorf("failed to delete container: %v", err)
+		}
 	}
 
-	// Check if the container is running
-	running, err := runtime.IsContainerRunning(ctx, containerID)
-	if err != nil {
-		return fmt.Errorf("failed to check if container is running: %v", err)
-	}
-
-	if !running {
-		logger.Log.Infof("Container %s is not running", containerName)
-		return nil
-	}
-
-	// Get the base container name
-	containerBaseName, _ := getContainerBaseName(ctx, runtime, containerID)
-
-	// Stop the proxy process
-	stopProxyProcess(containerBaseName)
-
-	// Stop the container
-	return stopContainer(ctx, runtime, containerID, containerName)
+	return nil
 }

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -1,0 +1,267 @@
+// Package lifecycle contains high-level logic for managing the lifecycle of
+// ToolHive-managed containers.
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/StacklokLabs/toolhive/pkg/client"
+	"github.com/StacklokLabs/toolhive/pkg/config"
+	ct "github.com/StacklokLabs/toolhive/pkg/container"
+	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
+	"github.com/StacklokLabs/toolhive/pkg/labels"
+	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/StacklokLabs/toolhive/pkg/process"
+	"github.com/StacklokLabs/toolhive/pkg/runner"
+)
+
+// Manager is responsible for managing the state of ToolHive-managed containers.
+// TODO: add Run and Restart here. This requires refactoring of the run code.
+type Manager interface {
+	// ListContainers lists all ToolHive-managed containers.
+	ListContainers(ctx context.Context, listAll bool) ([]rt.ContainerInfo, error)
+	// DeleteContainer deletes a container and its associated proxy process.
+	DeleteContainer(ctx context.Context, name string, forceDelete bool) error
+	// StopContainer stops a container and its associated proxy process.
+	StopContainer(ctx context.Context, name string) error
+}
+
+type defaultManager struct {
+	runtime rt.Runtime
+}
+
+// ErrContainerNotFound is returned when a container cannot be found by name.
+var (
+	ErrContainerNotFound   = fmt.Errorf("container not found")
+	ErrContainerNotRunning = fmt.Errorf("container not running")
+)
+
+// NewManager creates a new container manager instance.
+func NewManager(ctx context.Context) (Manager, error) {
+	runtime, err := ct.NewFactory().Create(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &defaultManager{
+		runtime: runtime,
+	}, nil
+}
+
+func (d *defaultManager) ListContainers(ctx context.Context, listAll bool) ([]rt.ContainerInfo, error) {
+	// List containers
+	containers, err := d.runtime.ListContainers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	// Filter containers to only show those managed by ToolHive
+	var toolHiveContainers []rt.ContainerInfo
+	for _, c := range containers {
+		// If the caller did not set `listAll` to true, only include running containers.
+		if labels.IsToolHiveContainer(c.Labels) && (c.State == "running" || listAll) {
+			toolHiveContainers = append(toolHiveContainers, c)
+		}
+	}
+
+	return toolHiveContainers, nil
+}
+
+func (d *defaultManager) DeleteContainer(ctx context.Context, name string, forceDelete bool) error {
+	// We need several fields from the container struct for deletion.
+	container, err := d.findContainerByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	containerID := container.ID
+	isRunning := container.State == "running"
+	containerLabels := container.Labels
+
+	// Check if the container is running and force is not specified
+	if isRunning && !forceDelete {
+		return fmt.Errorf("container %s is running. Use -f to force remove", name)
+	}
+
+	// Remove the container
+	logger.Log.Infof("Removing container %s...", name)
+	if err := d.runtime.RemoveContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to remove container: %v", err)
+	}
+
+	// Get the base name from the container labels
+	baseName := labels.GetContainerBaseName(containerLabels)
+	if baseName != "" {
+		// Delete the saved state if it exists
+		if err := runner.DeleteSavedConfig(ctx, baseName); err != nil {
+			logger.Log.Warnf("Warning: Failed to delete saved state: %v", err)
+		} else {
+			logger.Log.Infof("Saved state for %s removed", baseName)
+		}
+	}
+
+	logger.Log.Infof("Container %s removed", name)
+
+	if shouldRemoveClientConfig() {
+		if err := removeClientConfigurations(name); err != nil {
+			logger.Log.Warnf("Warning: Failed to remove client configurations: %v", err)
+		} else {
+			logger.Log.Infof("Client configurations for %s removed", name)
+		}
+	}
+
+	return nil
+}
+
+func (d *defaultManager) StopContainer(ctx context.Context, name string) error {
+	// Find the container ID
+	containerID, err := d.findContainerID(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	// Check if the container is running
+	running, err := d.runtime.IsContainerRunning(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to check if container is running: %v", err)
+	}
+
+	if !running {
+		return fmt.Errorf("%w: %s", ErrContainerNotRunning, name)
+	}
+
+	// Get the base container name
+	containerBaseName, _ := d.getContainerBaseName(ctx, containerID)
+
+	// Stop the proxy process
+	stopProxyProcess(containerBaseName)
+
+	// Stop the container
+	return d.stopContainer(ctx, containerID, name)
+}
+
+func (d *defaultManager) findContainerID(ctx context.Context, name string) (string, error) {
+	c, err := d.findContainerByName(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	return c.ID, nil
+}
+
+func (d *defaultManager) findContainerByName(ctx context.Context, name string) (*rt.ContainerInfo, error) {
+	// List containers to find the one with the given name
+	containers, err := d.runtime.ListContainers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	// Find the container with the given name
+	for _, c := range containers {
+		// Check if the container is managed by ToolHive
+		if !labels.IsToolHiveContainer(c.Labels) {
+			continue
+		}
+
+		// Check if the container name matches
+		containerName := labels.GetContainerName(c.Labels)
+		if containerName == "" {
+			name = c.Name // Fallback to container name
+		}
+
+		// Check if the name matches (exact match or prefix match)
+		if containerName == name || c.ID == name {
+			return &c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrContainerNotFound, name)
+}
+
+// stopProxyProcess stops the proxy process associated with the container
+func stopProxyProcess(containerBaseName string) {
+	if containerBaseName == "" {
+		logger.Log.Warnf("Warning: Could not find base container name in labels")
+		return
+	}
+
+	// Try to read the PID file and kill the process
+	pid, err := process.ReadPIDFile(containerBaseName)
+	if err != nil {
+		logger.Log.Errorf("No PID file found for %s, proxy may not be running in detached mode", containerBaseName)
+		return
+	}
+
+	// PID file found, try to kill the process
+	logger.Log.Infof("Stopping proxy process (PID: %d)...", pid)
+	if err := process.KillProcess(pid); err != nil {
+		logger.Log.Warnf("Warning: Failed to kill proxy process: %v", err)
+	} else {
+		logger.Log.Infof("Proxy process stopped")
+	}
+
+	// Remove the PID file
+	if err := process.RemovePIDFile(containerBaseName); err != nil {
+		logger.Log.Warnf("Warning: Failed to remove PID file: %v", err)
+	}
+}
+
+// getContainerBaseName gets the base container name from the container labels
+func (d *defaultManager) getContainerBaseName(ctx context.Context, containerID string) (string, error) {
+	containers, err := d.runtime.ListContainers(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	for _, c := range containers {
+		if c.ID == containerID {
+			return labels.GetContainerBaseName(c.Labels), nil
+		}
+	}
+
+	return "", fmt.Errorf("container %s not found", containerID)
+}
+
+// stopContainer stops the container
+func (d *defaultManager) stopContainer(ctx context.Context, containerID, containerName string) error {
+	logger.Log.Infof("Stopping container %s...", containerName)
+	if err := d.runtime.StopContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to stop container: %w", err)
+	}
+
+	logger.Log.Infof("Container %s stopped", containerName)
+	return nil
+}
+
+func shouldRemoveClientConfig() bool {
+	c := config.GetConfig()
+	return len(c.Clients.RegisteredClients) > 0 || c.Clients.AutoDiscovery
+}
+
+// TODO: Move to dedicated config management interface.
+// updateClientConfigurations updates client configuration files with the MCP server URL
+func removeClientConfigurations(containerName string) error {
+	// Find client configuration files
+	configs, err := client.FindClientConfigs()
+	if err != nil {
+		return fmt.Errorf("failed to find client configurations: %w", err)
+	}
+
+	if len(configs) == 0 {
+		logger.Log.Infof("No client configuration files found")
+		return nil
+	}
+
+	for _, c := range configs {
+		logger.Log.Infof("Removing MCP server from client configuration: %s", c.Path)
+
+		if err := c.ConfigUpdater.Remove(containerName); err != nil {
+			logger.Log.Warnf("Warning: Failed to remove MCP server from client configurationn %s: %v", c.Path, err)
+			continue
+		}
+
+		logger.Log.Infof("Successfully removed MCP server from client configuration: %s", c.Path)
+	}
+
+	return nil
+}


### PR DESCRIPTION
In order to allow the functionality of THV to be called from the CLI or REST API, we need to move business logic out of the implementation of the CLI. This PR is a first step which takes the rm, stop and list commands and moves them into a high-level "lifecycle" package. Various refactoring has been carried out to remove duplicated code.

Work for future PRs:

1) Move run and restart here. This will need refactoring of the code for
   starting a THV container.
2) Unit tests for the functionality in this package.
3) Refactoring some logic out of this lifecycle package, for example,
   proxy and client config management functions.