### PR TITLE
Move from StacklokLabs to stacklok org

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
 
     env:
-      BASE_REPO: "ghcr.io/stackloklabs/toolhive"
+      BASE_REPO: "ghcr.io/stacklok/toolhive"
 
     steps:
       - name: Checkout repository
@@ -63,7 +63,7 @@ jobs:
           fi
           
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv \
-            --image-label=org.opencontainers.image.source=https://github.com/StacklokLabs/toolhive,org.opencontainers.image.title="toolhive",org.opencontainers.image.vendor=Stacklok
+            --image-label=org.opencontainers.image.source=https://github.com/stacklok/toolhive,org.opencontainers.image.title="toolhive",org.opencontainers.image.vendor=Stacklok
 
       - name: Sign Image with Cosign
         # This step uses the identity token to provision an ephemeral certificate
@@ -86,7 +86,7 @@ jobs:
       id-token: write
 
     env:
-      BASE_REPO: "ghcr.io/stackloklabs/toolhive/operator"
+      BASE_REPO: "ghcr.io/stacklok/toolhive/operator"
 
     steps:
       - name: Checkout repository
@@ -146,7 +146,7 @@ jobs:
           fi
           
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv-operator \
-            --image-label=org.opencontainers.image.source=https://github.com/StacklokLabs/toolhive,org.opencontainers.image.title="toolhive-operator",org.opencontainers.image.vendor=Stacklok
+            --image-label=org.opencontainers.image.source=https://github.com/stacklok/toolhive,org.opencontainers.image.title="toolhive-operator",org.opencontainers.image.vendor=Stacklok
 
       - name: Sign Image with Cosign
         # This step uses the identity token to provision an ephemeral certificate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,7 +97,7 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/StacklokLabs/toolhive)
+        - prefix(github.com/stacklok/toolhive)
   exclusions:
     generated: lax
     paths:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,9 +12,9 @@ builds:
       - -tags=netgo
     ldflags:
       - "-s -w"
-      - "-X github.com/StacklokLabs/toolhive/pkg/versions.Version={{ .Env.VERSION }}"
-      - "-X github.com/StacklokLabs/toolhive/pkg/versions.Commit={{ .Env.COMMIT }}"
-      - "-X github.com/StacklokLabs/toolhive/pkg/versions.BuildDate={{ .Date }}"
+      - "-X github.com/stacklok/toolhive/pkg/versions.Version={{ .Env.VERSION }}"
+      - "-X github.com/stacklok/toolhive/pkg/versions.Commit={{ .Env.COMMIT }}"
+      - "-X github.com/stacklok/toolhive/pkg/versions.BuildDate={{ .Date }}"
     goos:
       - linux
 #      - windows
@@ -36,13 +36,13 @@ archives:
 #   - name: toolhive
 #     publisher: stacklok
 #     license: Apache-2.0
-#     license_url: "https://github.com/StacklokLabs/toolhive/blob/main/LICENSE"
+#     license_url: "https://github.com/stacklok/toolhive/blob/main/LICENSE"
 #     copyright: Stacklok, Inc.
 #     homepage: https://stacklok.com
 #     short_description: 'ToolHive is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers'
-#     publisher_support_url: "https://github.com/StacklokLabs/toolhive/issues/new/choose"
+#     publisher_support_url: "https://github.com/stacklok/toolhive/issues/new/choose"
 #     package_identifier: "stacklok.toolhive"
-#     url_template: "https://github.com/StacklokLabs/toolhive/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#     url_template: "https://github.com/stacklok/toolhive/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 #     skip_upload: auto
 #     release_notes: "{{.Changelog}}"
 #     tags:
@@ -67,7 +67,7 @@ archives:
 # This section defines how to release to homebrew.
 brews:
   - name: thv
-    homepage: 'https://github.com/StacklokLabs/toolhive'
+    homepage: 'https://github.com/stacklok/toolhive'
     description: 'ToolHive (thv) is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers'
     directory: Formula
     commit_author:
@@ -92,7 +92,7 @@ sboms:
 # This section defines the release policy.
 release:
   github:
-    owner: StacklokLabs
+    owner: stacklok
     name: toolhive
 # This section defines how and which artifacts we want to sign for the release.
 signs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for taking the time to contribute to ToolHive! :+1: :tada:
 ToolHive is released under the Apache 2.0 license. If you would like to
 contribute something or want to hack on the code, this document should help you
 get started. You can find some hints for starting development in ToolHive's
-[README](https://github.com/StacklokLabs/toolhive/blob/main/README.md).
+[README](https://github.com/stacklok/toolhive/blob/main/README.md).
 
 ## Table of contents <!-- omit from toc -->
 
@@ -20,7 +20,7 @@ get started. You can find some hints for starting development in ToolHive's
 ## Code of conduct
 
 This project adheres to the
-[Contributor Covenant](https://github.com/StacklokLabs/toolhive/blob/main/CODE_OF_CONDUCT.md)
+[Contributor Covenant](https://github.com/stacklok/toolhive/blob/main/CODE_OF_CONDUCT.md)
 code of conduct. By participating, you are expected to uphold this code. Please
 report unacceptable behavior to
 [code-of-conduct@stacklok.dev](mailto:code-of-conduct@stacklok.dev).
@@ -30,7 +30,7 @@ report unacceptable behavior to
 If you think you have found a security vulnerability in ToolHive please DO NOT
 disclose it publicly until we've had a chance to fix it. Please don't report
 security vulnerabilities using GitHub issues; instead, please follow this
-[process](https://github.com/StacklokLabs/toolhive/blob/main/SECURITY.md)
+[process](https://github.com/stacklok/toolhive/blob/main/SECURITY.md)
 
 ## How to contribute
 
@@ -46,8 +46,8 @@ sample project that reproduces the problem.
 
 ### Not sure how to start contributing?
 
-PRs to resolve existing issues are greatly appreciated and issues labeled as
-["good first issue"](https://github.com/StacklokLabs/toolhive/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+PRs to resolve existing issues are greatly appreciated, and issues labeled as
+["good first issue"](https://github.com/stacklok/toolhive/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 are a great place to start!
 
 ### Pull request process

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: toolhive.stacklok.dev
 layout:
 - go.kubebuilder.io/v3
 projectName: thv-operator
-repo: github.com/StacklokLabs/toolhive
+repo: github.com/stacklok/toolhive
 resources:
 - api:
     crdVersion: v1
@@ -11,6 +11,6 @@ resources:
   domain: toolhive.stacklok.dev
   group: toolhive
   kind: MCPServer
-  path: github.com/StacklokLabs/toolhive/cmd/thv-operator/api/v1alpha1
+  path: github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ToolHive - making MCP servers easy and secure <!-- omit in toc -->
 
-[![Release](https://img.shields.io/github/v/release/StacklokLabs/toolhive?style=flat&label=Latest%20version)](https://github.com/StacklokLabs/toolhive/releases)
+[![Release](https://img.shields.io/github/v/release/stacklok/toolhive?style=flat&label=Latest%20version)](https://github.com/stacklok/toolhive/releases)
 |
-[![CI](https://github.com/StacklokLabs/toolhive/actions/workflows/run-on-main.yml/badge.svg?event=push)](https://github.com/StacklokLabs/toolhive/actions/workflows/run-on-main.yml)
+[![CI](https://github.com/stacklok/toolhive/actions/workflows/run-on-main.yml/badge.svg?event=push)](https://github.com/stacklok/toolhive/actions/workflows/run-on-main.yml)
 |
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg?style=flat)](https://opensource.org/licenses/Apache-2.0)
 |
-[![Star on GitHub](https://img.shields.io/github/stars/StacklokLabs/toolhive.svg?style=flat&logo=github&label=Stars)](https://github.com/StacklokLabs/toolhive)
+[![Star on GitHub](https://img.shields.io/github/stars/stacklok/toolhive.svg?style=flat&logo=github&label=Stars)](https://github.com/stacklok/toolhive)
 |
 [![Discord](https://img.shields.io/discord/1184987096302239844?style=flat&logo=discord&label=Discord)](https://discord.gg/stacklok)
 
@@ -101,7 +101,7 @@ install it using one of the following methods:
 #### Download the binary <!-- omit in toc -->
 
 Download the latest cross-platform release binaries from
-[toolhive/releases](https://github.com/StacklokLabs/toolhive/releases).
+[toolhive/releases](https://github.com/stacklok/toolhive/releases).
 
 #### Homebrew (macOS) <!-- omit in toc -->
 
@@ -261,7 +261,7 @@ pull the image and start the server.
 
 We're always looking to expand our MCP server registry. If you have a specific
 server you'd like to see included, feel free to
-[open an issue](https://github.com/StacklokLabs/toolhive/issues) or submit a
+[open an issue](https://github.com/stacklok/toolhive/issues) or submit a
 pull request to update the [registry.json](pkg/registry/data/registry.json)
 file.
 
@@ -475,7 +475,7 @@ We welcome contributions to ToolHive! If you'd like to contribute, please review
 the [CONTRIBUTING guide](./CONTRIBUTING.md) for details on how to get started.
 
 If you run into a bug or have a feature request, please
-[open an issue](https://github.com/StacklokLabs/toolhive/issues) in the
+[open an issue](https://github.com/stacklok/toolhive/issues) in the
 repository or join us in the `#toolhive-developers` channel on our
 [community Discord server](https://discord.gg/stacklok).
 

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -7,7 +7,7 @@ your contributions.
 ## Reporting a vulnerability
 
 To report a security issue, please use the GitHub Security Advisory
-["Report a Vulnerability"](https://github.com/StacklokLabs/toolhive/security/advisories/new)
+["Report a Vulnerability"](https://github.com/stacklok/toolhive/security/advisories/new)
 tab.
 
 If you are unable to access GitHub you can also email us at
@@ -80,7 +80,7 @@ These steps should be completed within the 1-7 days of Disclosure.
 - Create a new
   [security advisory](https://docs.github.com/en/code-security/security-advisories/)
   in affected repository by visiting
-  `https://github.com/StacklokLabs/toolhive/security/advisories/new`
+  `https://github.com/stacklok/toolhive/security/advisories/new`
 - As many details as possible should be entered such as versions affected, CVE
   (if available yet). As more information is discovered, edit and update the
   advisory accordingly.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
       - mkdir -p bin
-      - go build -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv/app.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/cmd/thv/app.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/cmd/thv/app.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd/thv
+      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv/app.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd/thv
 
   install:
     desc: Install the thv binary to GOPATH/bin
@@ -55,7 +55,7 @@ tasks:
       BUILD_DATE:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
-      - go install -ldflags "-s -w -X github.com/StacklokLabs/toolhive/pkg/versions.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/pkg/versions.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/pkg/versions.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv
+      - go install -ldflags "-s -w -X github.com/stacklok/toolhive/pkg/versions.Version={{.VERSION}} -X github.com/stacklok/toolhive/pkg/versions.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/pkg/versions.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv
 
   all:
     desc: Run linting, tests, and build
@@ -123,7 +123,7 @@ tasks:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
       - mkdir -p bin
-      - go build -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -o bin/thv-operator ./cmd/thv-operator
+      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -o bin/thv-operator ./cmd/thv-operator
 
   install-operator:
     desc: Install the thv-operator binary to GOPATH/bin
@@ -135,7 +135,7 @@ tasks:
       BUILD_DATE:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
-      - go install -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv-operator
+      - go install -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv-operator
 
   build-operator-image:
     desc: Build the operator image with ko

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
-	cli "github.com/StacklokLabs/toolhive/cmd/thv/app"
+	cli "github.com/stacklok/toolhive/cmd/thv/app"
 )
 
 func main() {

--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/registry"
 )
 
 var (

--- a/cmd/regup/main.go
+++ b/cmd/regup/main.go
@@ -4,8 +4,8 @@ package main
 import (
 	"os"
 
-	"github.com/StacklokLabs/toolhive/cmd/regup/app"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/cmd/regup/app"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func main() {

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	mcpv1alpha1 "github.com/StacklokLabs/toolhive/cmd/thv-operator/api/v1alpha1"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // MCPServerReconciler reconciles a MCPServer object
@@ -633,7 +633,7 @@ func getToolhiveRunnerImage() string {
 	image := os.Getenv("TOOLHIVE_RUNNER_IMAGE")
 	if image == "" {
 		// Default to the published image
-		image = "ghcr.io/stackloklabs/toolhive:latest"
+		image = "ghcr.io/stacklok/toolhive:latest"
 	}
 	return image
 }

--- a/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	mcpv1alpha1 "github.com/StacklokLabs/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 )
 
 func TestDeploymentForMCPServerWithPodTemplateSpec(t *testing.T) {

--- a/cmd/thv-operator/main.go
+++ b/cmd/thv-operator/main.go
@@ -18,9 +18,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server" // Import for metricsserver
 	"sigs.k8s.io/controller-runtime/pkg/webhook"                      // Import for webhook
 
-	mcpv1alpha1 "github.com/StacklokLabs/toolhive/cmd/thv-operator/api/v1alpha1"
-	"github.com/StacklokLabs/toolhive/cmd/thv-operator/controllers"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 var (

--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/updates"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/updates"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // AddOIDCFlags adds OIDC validation flags to the provided command.

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/client"
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 var configCmd = &cobra.Command{

--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/client"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/client"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/lifecycle"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 var listCmd = &cobra.Command{

--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -7,9 +7,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/container"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 var (

--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/networking"
-	"github.com/StacklokLabs/toolhive/pkg/transport/proxy/transparent"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/transport/proxy/transparent"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 var proxyCmd = &cobra.Command{

--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/registry"
 )
 
 var registryCmd = &cobra.Command{

--- a/cmd/thv/app/restart.go
+++ b/cmd/thv/app/restart.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/process"
-	"github.com/StacklokLabs/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/lifecycle"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/process"
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 var restartCmd = &cobra.Command{

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
+	"github.com/stacklok/toolhive/pkg/lifecycle"
 )
 
 var rmCmd = &cobra.Command{

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -11,12 +11,12 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/registry"
-	"github.com/StacklokLabs/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/container"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 var runCmd = &cobra.Command{

--- a/cmd/thv/app/run_common.go
+++ b/cmd/thv/app/run_common.go
@@ -11,11 +11,11 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/authz"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/process"
-	"github.com/StacklokLabs/toolhive/pkg/runner"
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/authz"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/process"
+	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // var log = logger.GetLogger("run_common")

--- a/cmd/thv/app/run_protocol.go
+++ b/cmd/thv/app/run_protocol.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/container/templates"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/container/templates"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // Protocol schemes

--- a/cmd/thv/app/search.go
+++ b/cmd/thv/app/search.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/registry"
 )
 
 var searchCmd = &cobra.Command{

--- a/cmd/thv/app/secret.go
+++ b/cmd/thv/app/secret.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 func newSecretCommand() *cobra.Command {

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/lifecycle"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/lifecycle"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 var stopCmd = &cobra.Command{

--- a/cmd/thv/app/version.go
+++ b/cmd/thv/app/version.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/StacklokLabs/toolhive/pkg/versions"
+	"github.com/stacklok/toolhive/pkg/versions"
 )
 
 // newVersionCmd creates a new version command

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/StacklokLabs/toolhive/cmd/thv/app"
+	"github.com/stacklok/toolhive/cmd/thv/app"
 )
 
 func main() {

--- a/deploy/k8s/thv.yaml
+++ b/deploy/k8s/thv.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: toolhive
-        image: ko://github.com/StacklokLabs/toolhive/cmd
+        image: ko://github.com/stacklok/toolhive/cmd
         args: ["run", "--foreground=true", "--port=8080", "--name=mcp-fetch", "docker.io/mcp/fetch"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: toolhive-operator
       containers:
       - name: manager
-        image: ghcr.io/stackloklabs/toolhive/operator:latest
+        image: ghcr.io/stacklok/toolhive/operator:latest
         imagePullPolicy: Always
         args:
         - --leader-elect

--- a/deploy/operator/operator_local.yaml
+++ b/deploy/operator/operator_local.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: toolhive-operator
       containers:
       - name: manager
-        image: ko://github.com/StacklokLabs/toolhive/cmd/thv-operator
+        image: ko://github.com/stacklok/toolhive/cmd/thv-operator
         imagePullPolicy: Never
         args:
         - --leader-elect

--- a/docs/kind/deploying-mcp-server-with-operator.md
+++ b/docs/kind/deploying-mcp-server-with-operator.md
@@ -11,7 +11,7 @@ The [ToolHive Kubernetes Operator](../../cmd/thv-operator/README.md) manages MCP
 With the ToolHive Operator running, you can deploy an MCP server into the cluster by running the following:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/samples/mcpserver_fetch.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/samples/mcpserver_fetch.yaml
 ```
 
 You should now be able to see the MCP server pods being created/running:

--- a/docs/kind/deploying-toolhive-operator.md
+++ b/docs/kind/deploying-toolhive-operator.md
@@ -7,7 +7,7 @@ The [ToolHive Kubernetes Operator](../../cmd/thv-operator/README.md) manages MCP
 - kubectl configured to communicate with your cluster
 - Kind installed
 - Optional: [Task](https://taskfile.dev/installation/) to run automated steps with a cloned copy of the ToolHive repository
-  (`git clone https://github.com/StacklokLabs/toolhive`)
+  (`git clone https://github.com/stacklok/toolhive`)
 
 
 ## TL;DR
@@ -43,25 +43,25 @@ Once the cluster is running, follow these steps:
 1. Install the CRD:
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl create -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/crds/toolhive.stacklok.dev_mcpservers.yaml
 ```
 
 2. Create the operator namespace:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/namespace.yaml
 ```
 
 3. Set up RBAC:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/toolhive_rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/toolhive_rbac.yaml
 ```
 
 4. Deploy the operator:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/operator.yaml
 ```
 
 ## Installing the Operator Into an Existing Kind Cluster
@@ -85,24 +85,24 @@ $ task operator-deploy-local
 1. Install the CRD:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/crds/toolhive.stacklok.dev_mcpservers.yaml
 ```
 
 2. Create the operator namespace:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/namespace.yaml
 ```
 
 3. Set up RBAC:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/rbac.yaml
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/toolhive_rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/toolhive_rbac.yaml
 ```
 
 4. Deploy the operator:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/StacklokLabs/toolhive/main/deploy/operator/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/deploy/operator/operator.yaml
 ```

--- a/docs/kind/ingress.md
+++ b/docs/kind/ingress.md
@@ -6,7 +6,7 @@ This document walks through setting up Ingress in a local Kind cluster. There ar
 
 - A [kind](https://kind.sigs.k8s.io/) cluster running locally. Follow our [Setup a Local Kind Cluster](./setup-kind-cluster.md) to do this.
 - Optional: [Task](https://taskfile.dev/installation/) to run automated steps with a cloned copy of the ToolHive repository
-  (`git clone https://github.com/StacklokLabs/toolhive`)
+  (`git clone https://github.com/stacklok/toolhive`)
 
 ### Install Nginx Ingress Controller
 

--- a/docs/kind/setup-kind-cluster.md
+++ b/docs/kind/setup-kind-cluster.md
@@ -6,7 +6,7 @@ This document walks through setting up a local Kind cluster. There are many exam
 
 - Local container runtime is installed ([Docker](https://www.docker.com/), [Podman](https://podman.io/) etc)
 - Optional: [Task](https://taskfile.dev/installation/) to run automated steps with a cloned copy of the ToolHive repository
-  (`git clone https://github.com/StacklokLabs/toolhive`)
+  (`git clone https://github.com/stacklok/toolhive`)
 
 ## Installing Kind
 
@@ -54,7 +54,7 @@ $ kind delete clusters kind
 
 ### Automatic Setup: Setup & Destroy a Local Kind Cluster
 
-To automate the creation/destruction of a local Kind cluster, we have added a Task into the [`Taskfile.yml`](https://github.com/StacklokLabs/toolhive/blob/main/Taskfile.yml) in the root of the ToolHive repository.
+To automate the creation/destruction of a local Kind cluster, we have added a Task into the [`Taskfile.yml`](https://github.com/stacklok/toolhive/blob/main/Taskfile.yml) in the root of the ToolHive repository.
 
 #### Setup
 

--- a/docs/running-toolhive-in-kind-cluster.md
+++ b/docs/running-toolhive-in-kind-cluster.md
@@ -12,7 +12,7 @@ example MCP server.
 - [`ko`](https://ko.build/install/) to build the ToolHive image
 - [Task](https://taskfile.dev/installation/) to run automated steps
 - A copy of the ToolHive repository
-  (`git clone https://github.com/StacklokLabs/toolhive`)
+  (`git clone https://github.com/stacklok/toolhive`)
 
 ## Deploy an MCP server into a kind cluster
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/StacklokLabs/toolhive
+module github.com/stacklok/toolhive
 
 go 1.24.1
 

--- a/pkg/authz/cedar.go
+++ b/pkg/authz/cedar.go
@@ -12,7 +12,7 @@ import (
 	cedar "github.com/cedar-policy/cedar-go"
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth"
 )
 
 // Common errors for Cedar authorization

--- a/pkg/authz/cedar_test.go
+++ b/pkg/authz/cedar_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth"
 )
 
 // TestNewCedarAuthorizer tests the creation of a new Cedar authorizer with different configurations.

--- a/pkg/authz/config_test.go
+++ b/pkg/authz/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth"
 )
 
 func TestLoadConfig(t *testing.T) {

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	"github.com/StacklokLabs/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 )
 
 // MCPMethodToFeatureOperation maps MCP method names to feature and operation pairs.

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/jsonrpc2"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth"
 )
 
 func TestMiddleware(t *testing.T) {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/tailscale/hujson"
 
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 )
 
 // lockTimeout is the maximum time to wait for a file lock

--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tailscale/hujson"
 	"github.com/tidwall/gjson"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // ConfigUpdater defines the interface for types which can edit MCP client config files.

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 	"gotest.tools/assert"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestUpsertMCPServerConfig(t *testing.T) {

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 )
 
 // createMockClientConfigs creates a set of mock client configurations for testing

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gofrs/flock"
 	"gopkg.in/yaml.v3"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // lockTimeout is the maximum time to wait for a file lock

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // MockConfigPath replaces the getConfigPath function with a mock that returns a specified path

--- a/pkg/config/singleton.go
+++ b/pkg/config/singleton.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // Singleton value - should only be written to by the GetConfig function.

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -24,9 +24,9 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
 )
 
 // Common socket paths

--- a/pkg/container/docker/monitor.go
+++ b/pkg/container/docker/monitor.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
 
 // ContainerMonitor watches a container's state and reports when it exits

--- a/pkg/container/factory.go
+++ b/pkg/container/factory.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/StacklokLabs/toolhive/pkg/container/docker"
-	"github.com/StacklokLabs/toolhive/pkg/container/kubernetes"
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/container/docker"
+	"github.com/stacklok/toolhive/pkg/container/kubernetes"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
 
 // Factory creates container runtimes

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -28,10 +28,10 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/tools/watch"
 
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	transtypes "github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	transtypes "github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // Constants for container status

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func init() {

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/permissions"
 )
 
 // ContainerInfo represents information about a container

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // ParseSecretParameters parses the secret parameters from the command line,

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // mockSecretsProvider is a mock implementation of the secrets.Provider interface

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -6,14 +6,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/StacklokLabs/toolhive/pkg/client"
-	"github.com/StacklokLabs/toolhive/pkg/config"
-	ct "github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/process"
-	"github.com/StacklokLabs/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/config"
+	ct "github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/process"
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 // Manager is responsible for managing the state of ToolHive-managed containers.

--- a/pkg/networking/port.go
+++ b/pkg/networking/port.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"net"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 const (

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -4,7 +4,7 @@ package registry
 import (
 	"time"
 
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/permissions"
 )
 
 // Registry represents the top-level structure of the MCP registry

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -7,17 +7,17 @@ import (
 	"io"
 	"strings"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
-	"github.com/StacklokLabs/toolhive/pkg/authz"
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/environment"
-	"github.com/StacklokLabs/toolhive/pkg/labels"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/networking"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authz"
+	"github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/environment"
+	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // RunConfig contains all the configuration needed to run an MCP server

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/StacklokLabs/toolhive/pkg/authz"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/authz"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // mockRuntime implements the Runtime interface for testing

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -9,12 +9,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/StacklokLabs/toolhive/pkg/auth"
-	"github.com/StacklokLabs/toolhive/pkg/client"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/process"
-	"github.com/StacklokLabs/toolhive/pkg/transport"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/process"
+	"github.com/stacklok/toolhive/pkg/transport"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // Runner is responsible for running an MCP server with the provided configuration

--- a/pkg/runner/state_helpers.go
+++ b/pkg/runner/state_helpers.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/runner/state"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/runner/state"
 )
 
 // DefaultAppName is the default application name used for state storage

--- a/pkg/secrets/1password_test.go
+++ b/pkg/secrets/1password_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets"
-	"github.com/StacklokLabs/toolhive/pkg/secrets/mocks"
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
 
 func TestNewOnePasswordManager(t *testing.T) {

--- a/pkg/secrets/aes/aes_test.go
+++ b/pkg/secrets/aes/aes_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets/aes"
+	"github.com/stacklok/toolhive/pkg/secrets/aes"
 )
 
 func TestGCMEncrypt(t *testing.T) {

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -12,7 +12,7 @@ import (
 
 	"golang.org/x/sync/syncmap"
 
-	"github.com/StacklokLabs/toolhive/pkg/secrets/aes"
+	"github.com/stacklok/toolhive/pkg/secrets/aes"
 )
 
 // EncryptedManager stores secrets in an encrypted file.

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zalando/go-keyring"
 	"golang.org/x/term"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 const (

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -3,8 +3,8 @@
 package transport
 
 import (
-	"github.com/StacklokLabs/toolhive/pkg/transport/errors"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/transport/errors"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // Factory creates transports

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -13,9 +13,9 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/transport/ssecommon"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // Proxy defines the interface for proxying messages between clients and destinations.

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -13,8 +13,8 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // TransparentProxy implements the Proxy interface as a transparent HTTP proxy

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/networking"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/transport/errors"
-	"github.com/StacklokLabs/toolhive/pkg/transport/proxy/transparent"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/transport/errors"
+	"github.com/stacklok/toolhive/pkg/transport/proxy/transparent"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 const (

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -12,13 +12,13 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	"github.com/StacklokLabs/toolhive/pkg/container"
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/logger"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/transport/errors"
-	"github.com/StacklokLabs/toolhive/pkg/transport/proxy/httpsse"
-	"github.com/StacklokLabs/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/container"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/transport/errors"
+	"github.com/stacklok/toolhive/pkg/transport/proxy/httpsse"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // StdioTransport implements the Transport interface using standard input/output.

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -8,9 +8,9 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	rt "github.com/StacklokLabs/toolhive/pkg/container/runtime"
-	"github.com/StacklokLabs/toolhive/pkg/permissions"
-	"github.com/StacklokLabs/toolhive/pkg/transport/errors"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/transport/errors"
 )
 
 // Middleware is a function that wraps an http.Handler with additional functionality.

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/mod/semver"
 
-	"github.com/StacklokLabs/toolhive/pkg/versions"
+	"github.com/stacklok/toolhive/pkg/versions"
 )
 
 // UpdateChecker is an interface for checking if a new version of ToolHive is available.


### PR DESCRIPTION
The following PR adds the changes necessary for moving the project from StacklokLabs to the stacklok GitHub organisation.